### PR TITLE
Remove `Vec` from `DescriptorSetElementWrite` struct.

### DIFF
--- a/demo/src/assets/gltf/importer.rs
+++ b/demo/src/assets/gltf/importer.rs
@@ -284,6 +284,7 @@ impl Importer for GltfImporter {
                 material_to_import.asset.material_data.clone().into();
             slot_assignments.push(MaterialInstanceSlotAssignment {
                 slot_name: "per_material_data".to_string(),
+                array_index: 0,
                 image: None,
                 sampler: None,
                 buffer_data: Some(
@@ -299,6 +300,7 @@ impl Importer for GltfImporter {
             ) {
                 slot_assignments.push(MaterialInstanceSlotAssignment {
                     slot_name: slot_name.to_string(),
+                    array_index: 0,
                     image: Some(image.as_ref().map_or(default_image, |x| x).clone()),
                     sampler: None,
                     buffer_data: None,

--- a/rafx-assets/src/assets/asset_manager.rs
+++ b/rafx-assets/src/assets/asset_manager.rs
@@ -347,12 +347,15 @@ impl AssetManager {
                     location,
                     slot_assignment.slot_name
                 );
+
                 let layout_descriptor_set_writes =
                     &mut material_pass_write_set[location.layout_index as usize];
+
                 let write = layout_descriptor_set_writes
                     .elements
                     .get_mut(&DescriptorSetElementKey {
                         dst_binding: location.binding_index,
+                        array_index: slot_assignment.array_index,
                     })
                     .unwrap();
 
@@ -381,7 +384,7 @@ impl AssetManager {
                         }
                     }
 
-                    write.image_info = vec![write_image];
+                    write.image_info = write_image;
                 }
 
                 if what_to_bind.bind_buffers {
@@ -393,7 +396,7 @@ impl AssetManager {
                         ));
                     }
 
-                    write.buffer_info = vec![write_buffer];
+                    write.buffer_info = write_buffer;
                 }
             }
         }

--- a/rafx-assets/src/assets/graphics_pipeline/assets.rs
+++ b/rafx-assets/src/assets/graphics_pipeline/assets.rs
@@ -362,6 +362,8 @@ impl Deref for MaterialAsset {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct MaterialInstanceSlotAssignment {
     pub slot_name: String,
+    pub array_index: usize,
+
     pub image: Option<Handle<ImageAsset>>,
     pub sampler: Option<RafxSamplerDef>,
 

--- a/rafx-framework/src/resources/cooked_shader.rs
+++ b/rafx-framework/src/resources/cooked_shader.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 pub struct SlotLocation {
     pub layout_index: u32,
     pub binding_index: u32,
-    //pub array_index: u32,
 }
 
 pub type SlotNameLookup = FnvHashMap<String, FnvHashSet<SlotLocation>>;

--- a/rafx-framework/src/resources/descriptor_sets/descriptor_set_buffers.rs
+++ b/rafx-framework/src/resources/descriptor_sets/descriptor_set_buffers.rs
@@ -1,4 +1,4 @@
-use crate::resources::descriptor_sets::{DescriptorSetElementKey, MAX_DESCRIPTOR_SETS_PER_POOL};
+use crate::resources::descriptor_sets::{DescriptorSetBindingKey, MAX_DESCRIPTOR_SETS_PER_POOL};
 use fnv::FnvHashMap;
 use rafx_api::{
     RafxBuffer, RafxBufferDef, RafxDeviceContext, RafxMemoryUsage, RafxQueueType, RafxResourceType,
@@ -10,7 +10,7 @@ use rafx_api::{
 //
 #[derive(Clone)]
 pub(super) struct DescriptorSetPoolRequiredBufferInfo {
-    pub(super) dst_element: DescriptorSetElementKey,
+    pub(super) dst_element: DescriptorSetBindingKey,
     pub(super) descriptor_type: RafxResourceType,
     pub(super) per_descriptor_size: u32,
     pub(super) per_descriptor_stride: u32,
@@ -51,7 +51,7 @@ impl DescriptorBindingBufferSet {
 // Creates and manages the internal buffers for a descriptor pool chunk
 //
 pub(super) struct DescriptorLayoutBufferSet {
-    pub(super) buffer_sets: FnvHashMap<DescriptorSetElementKey, DescriptorBindingBufferSet>,
+    pub(super) buffer_sets: FnvHashMap<DescriptorSetBindingKey, DescriptorBindingBufferSet>,
 }
 
 impl DescriptorLayoutBufferSet {
@@ -59,7 +59,7 @@ impl DescriptorLayoutBufferSet {
         device_context: &RafxDeviceContext,
         buffer_infos: &[DescriptorSetPoolRequiredBufferInfo],
     ) -> RafxResult<Self> {
-        let mut buffer_sets: FnvHashMap<DescriptorSetElementKey, DescriptorBindingBufferSet> =
+        let mut buffer_sets: FnvHashMap<DescriptorSetBindingKey, DescriptorBindingBufferSet> =
             Default::default();
         for buffer_info in buffer_infos {
             let buffer = DescriptorBindingBufferSet::new(device_context, &buffer_info)?;

--- a/rafx-framework/src/resources/descriptor_sets/descriptor_set_pool.rs
+++ b/rafx-framework/src/resources/descriptor_sets/descriptor_set_pool.rs
@@ -1,7 +1,7 @@
 use super::ManagedDescriptorSet;
 use super::ManagedDescriptorSetPoolChunk;
 use super::{
-    DescriptorSetArc, DescriptorSetElementKey, DescriptorSetPoolRequiredBufferInfo,
+    DescriptorSetArc, DescriptorSetBindingKey, DescriptorSetPoolRequiredBufferInfo,
     DescriptorSetWriteSet, FrameInFlightIndex, MAX_DESCRIPTOR_SETS_PER_POOL, MAX_FRAMES_IN_FLIGHT,
 };
 use crate::resources::resource_lookup::DescriptorSetLayoutResource;
@@ -103,7 +103,7 @@ impl ManagedDescriptorSetPool {
                     per_descriptor_size,
                     per_descriptor_stride,
                     descriptor_type: binding.resource.resource_type,
-                    dst_element: DescriptorSetElementKey {
+                    dst_element: DescriptorSetBindingKey {
                         dst_binding: binding.resource.binding,
                     },
                 })

--- a/rafx-framework/src/resources/descriptor_sets/descriptor_set_pool_chunk.rs
+++ b/rafx-framework/src/resources/descriptor_sets/descriptor_set_pool_chunk.rs
@@ -3,9 +3,7 @@ use super::{
     DescriptorLayoutBufferSet, DescriptorSetElementKey, DescriptorSetPoolRequiredBufferInfo,
     DescriptorSetWriteSet, ManagedDescriptorSet, MAX_DESCRIPTOR_SETS_PER_POOL,
 };
-use crate::{
-    DescriptorSetArrayPoolAllocator, DescriptorSetLayoutResource, ResourceArc, ResourceDropSink,
-};
+use crate::{DescriptorSetArrayPoolAllocator, DescriptorSetLayoutResource, ResourceArc, ResourceDropSink};
 use fnv::FnvHashMap;
 use rafx_api::{
     RafxBuffer, RafxDescriptorElements, RafxDescriptorKey, RafxDescriptorSetArray,
@@ -14,6 +12,8 @@ use rafx_api::{
 };
 use rafx_base::slab::RawSlabKey;
 use std::collections::VecDeque;
+use crate::resources::descriptor_sets::DescriptorSetBindingKey;
+use crate::descriptor_sets::DescriptorSetElementWrite;
 
 // A write to the descriptors within a single descriptor set that has been scheduled (i.e. will occur
 // over the next MAX_FRAMES_IN_FLIGHT_PLUS_1 frames
@@ -150,7 +150,9 @@ impl ManagedDescriptorSetPoolChunk {
             }
         }
 
-        let descriptor_set_array = self.descriptor_set_array.as_mut().unwrap();
+        let descriptor_set_array = {
+            self.descriptor_set_array.as_mut().unwrap()
+        };
 
         for (key, element) in all_set_writes {
             let slab_key = key.0;
@@ -167,162 +169,197 @@ impl ManagedDescriptorSetPoolChunk {
                 self.descriptor_set_layout,
             );
 
-            if !element.image_info.is_empty() {
-                for (image_info_index, image_info) in element.image_info.iter().enumerate() {
-                    if element.has_immutable_sampler
-                        && element.descriptor_type.intersects(
-                            RafxResourceType::SAMPLER | RafxResourceType::COMBINED_IMAGE_SAMPLER,
-                        )
-                    {
-                        // Skip any sampler bindings if the binding is populated with an immutable sampler
-                        continue;
-                    }
+            ManagedDescriptorSetPoolChunk::try_queue_descriptor_set_image_update(
+                descriptor_set_array,
+                descriptor_set_index,
+                element_key,
+                element
+            )?;
 
-                    if image_info.sampler.is_none() && image_info.image_view.is_none() {
-                        // Don't bind anything that has both a null sampler and image_view
-                        //TODO: Could set back to default state
-                        continue;
-                    }
-
-                    if let Some(image_view) = &image_info.image_view {
-                        descriptor_set_array.queue_descriptor_set_update(
-                            &RafxDescriptorUpdate {
-                                array_index: descriptor_set_index,
-                                descriptor_key: RafxDescriptorKey::Binding(element_key.dst_binding),
-                                elements: RafxDescriptorElements {
-                                    textures: Some(&[&image_view.get_image()]),
-                                    ..Default::default()
-                                },
-                                dst_element_offset: image_info_index as u32,
-                                texture_bind_type: Default::default(),
-                            },
-                        )?;
-                    }
-
-                    // Skip adding samplers if the binding is populated with an immutable sampler
-                    // (this case is hit when using CombinedImageSampler)
-                    if !element.has_immutable_sampler {
-                        if let Some(sampler) = &image_info.sampler {
-                            descriptor_set_array.queue_descriptor_set_update(
-                                &RafxDescriptorUpdate {
-                                    array_index: descriptor_set_index,
-                                    descriptor_key: RafxDescriptorKey::Binding(
-                                        element_key.dst_binding,
-                                    ),
-                                    elements: RafxDescriptorElements {
-                                        samplers: Some(&[&sampler.get_raw().sampler]),
-                                        ..Default::default()
-                                    },
-                                    dst_element_offset: image_info_index as u32,
-                                    texture_bind_type: Default::default(),
-                                },
-                            )?;
-                        }
-                    }
-                }
-            }
-
-            if !element.buffer_info.is_empty() {
-                for (buffer_info_index, buffer_info) in element.buffer_info.iter().enumerate() {
-                    if let Some(buffer_info) = &buffer_info.buffer {
-                        match buffer_info {
-                            DescriptorSetWriteElementBufferData::BufferRef(buffer) => {
-                                let mut offset_sizes = None;
-                                if buffer.byte_offset.is_some() || buffer.size.is_some() {
-                                    offset_sizes = Some([RafxOffsetSize {
-                                        byte_offset: buffer.byte_offset.unwrap_or(0),
-                                        size: buffer.size.unwrap_or(0),
-                                    }])
-                                }
-
-                                descriptor_set_array.queue_descriptor_set_update(
-                                    &RafxDescriptorUpdate {
-                                        array_index: descriptor_set_index,
-                                        descriptor_key: RafxDescriptorKey::Binding(
-                                            element_key.dst_binding,
-                                        ),
-                                        elements: RafxDescriptorElements {
-                                            buffers: Some(&[&*buffer.buffer.get_raw().buffer]),
-                                            buffer_offset_sizes: offset_sizes
-                                                .as_ref()
-                                                .map(|x| &x[..]),
-                                            ..Default::default()
-                                        },
-                                        dst_element_offset: buffer_info_index as u32,
-                                        texture_bind_type: Default::default(),
-                                    },
-                                )?;
-                            }
-                            DescriptorSetWriteElementBufferData::Data(data) => {
-                                //TODO: Rebind the buffer if we are no longer bound to the internal buffer, or at
-                                // least fail
-                                // Failing here means that we're trying to write to a descriptor's internal buffer
-                                // but the binding was not configured to enabled internal buffering
-                                let buffer =
-                                    self.buffers.buffer_sets.get_mut(&element_key).unwrap();
-                                //assert!(data.len() as u32 <= buffer.buffer_info.per_descriptor_size);
-                                if data.len() as u32 > buffer.buffer_info.per_descriptor_size {
-                                    panic!(
-                                        "Wrote {} bytes to a descriptor set buffer that holds {} bytes layout: {:?}",
-                                        data.len(),
-                                        buffer.buffer_info.per_descriptor_size,
-                                        self.descriptor_set_layout
-                                    );
-                                }
-
-                                if data.len() as u32 != buffer.buffer_info.per_descriptor_size {
-                                    log::warn!(
-                                        "Wrote {} bytes to a descriptor set buffer that holds {} bytes layout: {:?}",
-                                        data.len(),
-                                        buffer.buffer_info.per_descriptor_size,
-                                        self.descriptor_set_layout
-                                    );
-                                }
-
-                                let descriptor_set_index =
-                                    slab_key.index() % MAX_DESCRIPTOR_SETS_PER_POOL;
-                                let offset =
-                                    buffer.buffer_info.per_descriptor_stride * descriptor_set_index;
-
-                                log::trace!(
-                                    "Writing {} bytes to internal buffer to set {} at offset {}",
-                                    data.len(),
-                                    descriptor_set_index,
-                                    offset
-                                );
-                                buffer
-                                    .buffer
-                                    .copy_to_host_visible_buffer_with_offset(&data, offset as u64)
-                                    .unwrap();
-
-                                //TODO: If we bound this as BufferRef, we would need to reset it back to Data
-
-                                // descriptor_set_array.queue_descriptor_set_update(&RafxDescriptorUpdate {
-                                //     array_index: descriptor_set_index,
-                                //     descriptor_key: RafxDescriptorKey::Binding(element_key.dst_binding),
-                                //     elements: RafxDescriptorElements {
-                                //         buffers: Some(&[&buffer.buffer]),
-                                //         buffer_offset_sizes: Some(&[
-                                //             RafxOffsetSize {
-                                //                 offset: offset as u64,
-                                //                 size: buffer.buffer_info.per_descriptor_size as u64
-                                //             }
-                                //         ]),
-                                //         ..Default::default()
-                                //     },
-                                //     dst_element_offset: buffer_info_index as u32,
-                                //     texture_bind_type: Default::default(),
-                                // });
-                            }
-                        }
-                    }
-                }
-            }
+            ManagedDescriptorSetPoolChunk::try_queue_descriptor_set_buffer_update(
+                &mut self.buffers,
+                &self.descriptor_set_layout.get_raw(),
+                descriptor_set_array,
+                descriptor_set_index,
+                element_key,
+                element
+            )?;
         }
 
         descriptor_set_array.flush_descriptor_set_updates()?;
 
         self.pending_set_writes.clear();
+        Ok(())
+    }
+
+    fn try_queue_descriptor_set_image_update(
+        descriptor_set_array: &mut RafxDescriptorSetArray,
+        descriptor_set_index: u32,
+        element_key: DescriptorSetElementKey,
+        element: &DescriptorSetElementWrite
+    ) -> RafxResult<()> {
+        if element.has_immutable_sampler
+            && element.descriptor_type.intersects(
+            RafxResourceType::SAMPLER | RafxResourceType::COMBINED_IMAGE_SAMPLER,
+        )
+        {
+            // Skip any sampler bindings if the binding is populated with an immutable sampler
+            return Ok(());
+        }
+
+        let image_info = &element.image_info;
+        let image_info_index = element_key.array_index;
+
+        if image_info.sampler.is_none() && image_info.image_view.is_none() {
+            // Don't bind anything that has both a null sampler and image_view
+            //TODO: Could set back to default state
+            return Ok(());
+        }
+
+        if let Some(image_view) = &image_info.image_view {
+            descriptor_set_array.queue_descriptor_set_update(
+                &RafxDescriptorUpdate {
+                    array_index: descriptor_set_index,
+                    descriptor_key: RafxDescriptorKey::Binding(element_key.dst_binding),
+                    elements: RafxDescriptorElements {
+                        textures: Some(&[&image_view.get_image()]),
+                        ..Default::default()
+                    },
+                    dst_element_offset: image_info_index as u32,
+                    texture_bind_type: Default::default(),
+                },
+            )?;
+        }
+
+        // Skip adding samplers if the binding is populated with an immutable sampler
+        // (this case is hit when using CombinedImageSampler)
+        if !element.has_immutable_sampler {
+            if let Some(sampler) = &image_info.sampler {
+                descriptor_set_array.queue_descriptor_set_update(
+                    &RafxDescriptorUpdate {
+                        array_index: descriptor_set_index,
+                        descriptor_key: RafxDescriptorKey::Binding(
+                            element_key.dst_binding,
+                        ),
+                        elements: RafxDescriptorElements {
+                            samplers: Some(&[&sampler.get_raw().sampler]),
+                            ..Default::default()
+                        },
+                        dst_element_offset: image_info_index as u32,
+                        texture_bind_type: Default::default(),
+                    },
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn try_queue_descriptor_set_buffer_update(
+        buffers: &mut DescriptorLayoutBufferSet,
+        descriptor_set_layout: &DescriptorSetLayoutResource,
+        descriptor_set_array: &mut RafxDescriptorSetArray,
+        descriptor_set_index: u32,
+        element_key: DescriptorSetElementKey,
+        element: &DescriptorSetElementWrite
+    ) -> RafxResult<()> {
+        let buffer_info = &element.buffer_info;
+        let buffer_info_index = element_key.array_index;
+
+        if let Some(buffer_info) = &buffer_info.buffer {
+            match buffer_info {
+                DescriptorSetWriteElementBufferData::BufferRef(buffer) => {
+                    let mut offset_sizes = None;
+                    if buffer.byte_offset.is_some() || buffer.size.is_some() {
+                        offset_sizes = Some([RafxOffsetSize {
+                            byte_offset: buffer.byte_offset.unwrap_or(0),
+                            size: buffer.size.unwrap_or(0),
+                        }])
+                    }
+
+                    descriptor_set_array.queue_descriptor_set_update(
+                        &RafxDescriptorUpdate {
+                            array_index: descriptor_set_index,
+                            descriptor_key: RafxDescriptorKey::Binding(
+                                element_key.dst_binding,
+                            ),
+                            elements: RafxDescriptorElements {
+                                buffers: Some(&[&*buffer.buffer.get_raw().buffer]),
+                                buffer_offset_sizes: offset_sizes
+                                    .as_ref()
+                                    .map(|x| &x[..]),
+                                ..Default::default()
+                            },
+                            dst_element_offset: buffer_info_index as u32,
+                            texture_bind_type: Default::default(),
+                        },
+                    )?;
+                }
+                DescriptorSetWriteElementBufferData::Data(data) => {
+                    //TODO: Rebind the buffer if we are no longer bound to the internal buffer, or at
+                    // least fail
+                    // Failing here means that we're trying to write to a descriptor's internal buffer
+                    // but the binding was not configured to enabled internal buffering
+                    let buffer =
+                        buffers.buffer_sets.get_mut(&DescriptorSetBindingKey {
+                            dst_binding: element_key.dst_binding
+                        }).unwrap();
+
+                    //assert!(data.len() as u32 <= buffer.buffer_info.per_descriptor_size);
+                    if data.len() as u32 > buffer.buffer_info.per_descriptor_size {
+                        panic!(
+                            "Wrote {} bytes to a descriptor set buffer that holds {} bytes layout: {:?}",
+                            data.len(),
+                            buffer.buffer_info.per_descriptor_size,
+                            descriptor_set_layout
+                        );
+                    }
+
+                    if data.len() as u32 != buffer.buffer_info.per_descriptor_size {
+                        log::warn!(
+                            "Wrote {} bytes to a descriptor set buffer that holds {} bytes layout: {:?}",
+                            data.len(),
+                            buffer.buffer_info.per_descriptor_size,
+                            descriptor_set_layout
+                        );
+                    }
+
+                    let offset =
+                        buffer.buffer_info.per_descriptor_stride * descriptor_set_index;
+
+                    log::trace!(
+                        "Writing {} bytes to internal buffer to set {} at offset {}",
+                        data.len(),
+                        descriptor_set_index,
+                        offset
+                    );
+                    buffer
+                        .buffer
+                        .copy_to_host_visible_buffer_with_offset(&data, offset as u64)
+                        .unwrap();
+
+                    //TODO: If we bound this as BufferRef, we would need to reset it back to Data
+
+                    // descriptor_set_array.queue_descriptor_set_update(&RafxDescriptorUpdate {
+                    //     array_index: descriptor_set_index,
+                    //     descriptor_key: RafxDescriptorKey::Binding(element_key.dst_binding),
+                    //     elements: RafxDescriptorElements {
+                    //         buffers: Some(&[&buffer.buffer]),
+                    //         buffer_offset_sizes: Some(&[
+                    //             RafxOffsetSize {
+                    //                 offset: offset as u64,
+                    //                 size: buffer.buffer_info.per_descriptor_size as u64
+                    //             }
+                    //         ]),
+                    //         ..Default::default()
+                    //     },
+                    //     dst_element_offset: buffer_info_index as u32,
+                    //     texture_bind_type: Default::default(),
+                    // });
+                }
+            }
+        }
+
         Ok(())
     }
 }

--- a/rafx-framework/src/resources/descriptor_sets/descriptor_write_set.rs
+++ b/rafx-framework/src/resources/descriptor_sets/descriptor_write_set.rs
@@ -76,13 +76,13 @@ pub struct DescriptorSetElementWrite {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct DescriptorSetElementKey {
     pub dst_binding: u32,
-    pub array_index: usize
+    pub array_index: usize,
 }
 
 // Represents an "index" of a binding within a layout.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct DescriptorSetBindingKey {
-    pub dst_binding: u32
+    pub dst_binding: u32,
 }
 
 // A set of writes to descriptors within a descriptor set
@@ -117,7 +117,7 @@ pub fn create_uninitialized_write_set_for_layout(
 
             let key = DescriptorSetElementKey {
                 dst_binding: binding.resource.binding as u32,
-                array_index: array_index as usize
+                array_index: array_index as usize,
             };
 
             write_set.elements.insert(key, element_write);

--- a/rafx-framework/src/resources/descriptor_sets/dynamic_descriptor_sets.rs
+++ b/rafx-framework/src/resources/descriptor_sets/dynamic_descriptor_sets.rs
@@ -157,7 +157,7 @@ impl DynDescriptorSet {
     ) {
         let key = DescriptorSetElementKey {
             dst_binding: binding_index,
-            array_index
+            array_index,
         };
 
         if let Some(element) = self.write_set.elements.get_mut(&key) {
@@ -201,7 +201,7 @@ impl DynDescriptorSet {
     ) {
         let key = DescriptorSetElementKey {
             dst_binding: binding_index,
-            array_index
+            array_index,
         };
 
         if let Some(element) = self.write_set.elements.get_mut(&key) {
@@ -255,7 +255,7 @@ impl DynDescriptorSet {
         //TODO: Verify that T's size matches the buffer
         let key = DescriptorSetElementKey {
             dst_binding: binding_index,
-            array_index
+            array_index,
         };
 
         if let Some(element) = self.write_set.elements.get_mut(&key) {
@@ -264,7 +264,7 @@ impl DynDescriptorSet {
                 let data = rafx_base::memory::any_as_bytes(data).into();
 
                 element.buffer_info.buffer = Some(DescriptorSetWriteElementBufferData::Data(data));
-                
+
                 self.pending_write_set.elements.insert(key, element.clone());
             } else {
                 // This is not necessarily an error if the user is binding with a slot name (although not sure

--- a/rafx-framework/src/resources/descriptor_sets/dynamic_descriptor_sets.rs
+++ b/rafx-framework/src/resources/descriptor_sets/dynamic_descriptor_sets.rs
@@ -157,20 +157,15 @@ impl DynDescriptorSet {
     ) {
         let key = DescriptorSetElementKey {
             dst_binding: binding_index,
+            array_index
         };
 
         if let Some(element) = self.write_set.elements.get_mut(&key) {
             let what_to_bind = super::what_to_bind(element);
             if what_to_bind.bind_images {
-                if let Some(element_image) = element.image_info.get_mut(array_index) {
-                    element_image.image_view = Some(image_view);
+                element.image_info.image_view = Some(image_view);
 
-                    self.pending_write_set.elements.insert(key, element.clone());
-
-                //self.dirty.insert(key);
-                } else {
-                    log::warn!("Tried to set image index {} but it did not exist. The image array is {} elements long.", array_index, element.image_info.len());
-                }
+                self.pending_write_set.elements.insert(key, element.clone());
             } else {
                 // This is not necessarily an error if the user is binding with a slot name (although not sure
                 // if that's the right approach long term)
@@ -206,26 +201,21 @@ impl DynDescriptorSet {
     ) {
         let key = DescriptorSetElementKey {
             dst_binding: binding_index,
+            array_index
         };
 
         if let Some(element) = self.write_set.elements.get_mut(&key) {
             let what_to_bind = super::what_to_bind(element);
             if what_to_bind.bind_buffers {
-                if let Some(element_buffer) = element.buffer_info.get_mut(array_index) {
-                    element_buffer.buffer = Some(DescriptorSetWriteElementBufferData::BufferRef(
-                        DescriptorSetWriteElementBufferDataBufferRef {
-                            buffer: buffer.clone(),
-                            byte_offset: None,
-                            size: None,
-                        },
-                    ));
+                element.buffer_info.buffer = Some(DescriptorSetWriteElementBufferData::BufferRef(
+                    DescriptorSetWriteElementBufferDataBufferRef {
+                        buffer: buffer.clone(),
+                        byte_offset: None,
+                        size: None,
+                    },
+                ));
 
-                    self.pending_write_set.elements.insert(key, element.clone());
-
-                //self.dirty.insert(key);
-                } else {
-                    log::warn!("Tried to set buffer index {} but it did not exist. The image array is {} elements long.", array_index, element.buffer_info.len());
-                }
+                self.pending_write_set.elements.insert(key, element.clone());
             } else {
                 // This is not necessarily an error if the user is binding with a slot name (although not sure
                 // if that's the right approach long term)
@@ -265,18 +255,17 @@ impl DynDescriptorSet {
         //TODO: Verify that T's size matches the buffer
         let key = DescriptorSetElementKey {
             dst_binding: binding_index,
+            array_index
         };
 
         if let Some(element) = self.write_set.elements.get_mut(&key) {
             let what_to_bind = super::what_to_bind(element);
             if what_to_bind.bind_buffers {
                 let data = rafx_base::memory::any_as_bytes(data).into();
-                if let Some(element_buffer) = element.buffer_info.get_mut(array_index) {
-                    element_buffer.buffer = Some(DescriptorSetWriteElementBufferData::Data(data));
-                    self.pending_write_set.elements.insert(key, element.clone());
-                } else {
-                    log::warn!("Tried to set buffer data for index {} but it did not exist. The buffer array is {} elements long.", array_index, element.buffer_info.len());
-                }
+
+                element.buffer_info.buffer = Some(DescriptorSetWriteElementBufferData::Data(data));
+                
+                self.pending_write_set.elements.insert(key, element.clone());
             } else {
                 // This is not necessarily an error if the user is binding with a slot name (although not sure
                 // if that's the right approach long term)

--- a/rafx-framework/src/resources/descriptor_sets/mod.rs
+++ b/rafx-framework/src/resources/descriptor_sets/mod.rs
@@ -22,8 +22,8 @@ use descriptor_set_buffers::DescriptorSetPoolRequiredBufferInfo;
 
 mod descriptor_write_set;
 pub use descriptor_write_set::create_uninitialized_write_set_for_layout;
-pub use descriptor_write_set::DescriptorSetElementKey;
 pub use descriptor_write_set::DescriptorSetBindingKey;
+pub use descriptor_write_set::DescriptorSetElementKey;
 pub use descriptor_write_set::DescriptorSetElementWrite;
 pub use descriptor_write_set::DescriptorSetWriteElementBuffer;
 pub use descriptor_write_set::DescriptorSetWriteElementBufferData;

--- a/rafx-framework/src/resources/descriptor_sets/mod.rs
+++ b/rafx-framework/src/resources/descriptor_sets/mod.rs
@@ -23,6 +23,7 @@ use descriptor_set_buffers::DescriptorSetPoolRequiredBufferInfo;
 mod descriptor_write_set;
 pub use descriptor_write_set::create_uninitialized_write_set_for_layout;
 pub use descriptor_write_set::DescriptorSetElementKey;
+pub use descriptor_write_set::DescriptorSetBindingKey;
 pub use descriptor_write_set::DescriptorSetElementWrite;
 pub use descriptor_write_set::DescriptorSetWriteElementBuffer;
 pub use descriptor_write_set::DescriptorSetWriteElementBufferData;


### PR DESCRIPTION
Each `DescriptorSetElementWrite` now represents a single index with a binding. If a binding has multiple elements, there will be one `DescriptorSetElementWrite` for each element. `DescriptorSetElementKey` now contains the `array_index` field representing which element the write is targeting. For cases where that doesn't matter, see `DescriptorSetBindingKey` containing just the `dst_binding` field.

The `MaterialInstanceSlotAssignment` now contains the `array_index` so that it can be used to create a `DescriptorSetElementKey`.