### PR TITLE
Remove add_render_node_reservations

### DIFF
--- a/demo/src/features/mesh/extract.rs
+++ b/demo/src/features/mesh/extract.rs
@@ -47,6 +47,7 @@ impl ExtractJob for MeshExtractJob {
         let mut mesh_render_nodes = extract_context
             .extract_resources
             .fetch_mut::<MeshRenderNodeSet>();
+        mesh_render_nodes.update();
 
         let mut query = <(Read<PositionComponent>, Read<MeshComponent>)>::query();
         for (position_component, mesh_component) in query.iter(world) {

--- a/demo/src/features/mesh/plugin.rs
+++ b/demo/src/features/mesh/plugin.rs
@@ -1,5 +1,5 @@
 use crate::features::mesh::shadow_map_resource::ShadowMapResource;
-use crate::features::mesh::{MeshRenderFeature, MeshRenderNodeSet};
+use crate::features::mesh::MeshRenderFeature;
 use distill::loader::handle::Handle;
 use rafx::api::extra::upload::RafxTransferUpload;
 use rafx::api::RafxResult;
@@ -8,8 +8,8 @@ use rafx::assets::{AssetManager, MaterialAsset};
 use rafx::base::resource_map::ResourceMap;
 use rafx::framework::RenderResources;
 use rafx::nodes::{
-    ExtractJob, ExtractResources, FramePacketBuilder, RenderNodeReservations,
-    RenderRegistryBuilder, RenderView, RenderViewSet,
+    ExtractJob, ExtractResources, FramePacketBuilder, RenderRegistryBuilder, RenderView,
+    RenderViewSet,
 };
 use rafx::renderer::RendererPlugin;
 use rafx::visibility::{DynamicVisibilityNodeSet, StaticVisibilityNodeSet};
@@ -46,17 +46,6 @@ impl RendererPlugin for MeshRendererPlugin {
         render_resources.insert(ShadowMapResource::default());
 
         Ok(())
-    }
-
-    fn add_render_node_reservations(
-        &self,
-        render_node_reservations: &mut RenderNodeReservations,
-        extract_resources: &ExtractResources,
-        _render_resources: &RenderResources,
-    ) {
-        let mut mesh_render_nodes = extract_resources.fetch_mut::<MeshRenderNodeSet>();
-        mesh_render_nodes.update();
-        render_node_reservations.add_reservation(&*mesh_render_nodes);
     }
 
     fn add_extract_jobs(

--- a/demo/src/features/sprite/extract.rs
+++ b/demo/src/features/sprite/extract.rs
@@ -39,6 +39,7 @@ impl ExtractJob for SpriteExtractJob {
         let mut sprite_render_nodes = extract_context
             .extract_resources
             .fetch_mut::<SpriteRenderNodeSet>();
+        sprite_render_nodes.update();
 
         let mut query = <(Read<PositionComponent>, Read<SpriteComponent>)>::query();
         for (position_component, sprite_component) in query.iter(world) {

--- a/demo/src/features/sprite/plugin.rs
+++ b/demo/src/features/sprite/plugin.rs
@@ -1,4 +1,4 @@
-use crate::features::sprite::{SpriteRenderFeature, SpriteRenderNodeSet};
+use crate::features::sprite::SpriteRenderFeature;
 use rafx::api::extra::upload::RafxTransferUpload;
 use rafx::api::RafxResult;
 use rafx::assets::distill_impl::AssetResource;
@@ -6,7 +6,7 @@ use rafx::assets::{AssetManager, MaterialAsset};
 use rafx::base::resource_map::ResourceMap;
 use rafx::distill::loader::handle::Handle;
 use rafx::framework::RenderResources;
-use rafx::nodes::{ExtractJob, ExtractResources, RenderNodeReservations, RenderRegistryBuilder};
+use rafx::nodes::{ExtractJob, ExtractResources, RenderRegistryBuilder};
 use rafx::renderer::RendererPlugin;
 
 pub struct SpriteStaticResources {
@@ -43,17 +43,6 @@ impl RendererPlugin for SpriteRendererPlugin {
         render_resources.insert(SpriteStaticResources { sprite_material });
 
         Ok(())
-    }
-
-    fn add_render_node_reservations(
-        &self,
-        render_node_reservations: &mut RenderNodeReservations,
-        extract_resources: &ExtractResources,
-        _render_resources: &RenderResources,
-    ) {
-        let mut sprite_render_nodes = extract_resources.fetch_mut::<SpriteRenderNodeSet>();
-        sprite_render_nodes.update();
-        render_node_reservations.add_reservation(&*sprite_render_nodes);
     }
 
     fn add_extract_jobs(

--- a/rafx-framework/src/nodes/mod.rs
+++ b/rafx-framework/src/nodes/mod.rs
@@ -4,7 +4,6 @@ mod render_nodes;
 pub use render_nodes::GenericRenderNodeHandle;
 pub use render_nodes::RenderNodeCount;
 pub use render_nodes::RenderNodeIndex;
-pub use render_nodes::RenderNodeReservations;
 pub use render_nodes::RenderNodeSet;
 
 mod submit_nodes;

--- a/rafx-framework/src/nodes/render_nodes.rs
+++ b/rafx-framework/src/nodes/render_nodes.rs
@@ -1,5 +1,4 @@
 use super::RenderFeatureIndex;
-use super::RenderRegistry;
 use rafx_base::slab::SlabIndexT;
 
 pub type RenderNodeIndex = u32;
@@ -34,34 +33,4 @@ impl GenericRenderNodeHandle {
 pub trait RenderNodeSet {
     fn feature_index(&self) -> RenderFeatureIndex;
     fn max_render_node_count(&self) -> RenderNodeCount;
-}
-
-pub struct RenderNodeReservations {
-    max_render_nodes_by_feature: Vec<u32>,
-}
-
-impl Default for RenderNodeReservations {
-    fn default() -> Self {
-        let feature_count = RenderRegistry::registered_feature_count();
-        let max_render_nodes_by_feature = vec![0; feature_count as usize];
-
-        RenderNodeReservations {
-            max_render_nodes_by_feature,
-        }
-    }
-}
-
-impl RenderNodeReservations {
-    pub fn add_reservation(
-        &mut self,
-        render_nodes: &dyn RenderNodeSet,
-    ) {
-        // A panic here means a feature was not registered
-        self.max_render_nodes_by_feature[render_nodes.feature_index() as usize] +=
-            render_nodes.max_render_node_count();
-    }
-
-    pub fn max_render_nodes_by_feature(&self) -> &[u32] {
-        &self.max_render_nodes_by_feature
-    }
 }

--- a/rafx-renderer/src/renderer.rs
+++ b/rafx-renderer/src/renderer.rs
@@ -2,8 +2,7 @@ use rafx_assets::distill_impl::AssetResource;
 use rafx_assets::{image_upload, AssetManagerRenderResource, GpuImageDataColorSpace};
 use rafx_assets::{AssetManager, GpuImageData};
 use rafx_framework::nodes::{
-    ExtractJobSet, ExtractResources, FramePacketBuilder, RenderJobExtractContext,
-    RenderNodeReservations, RenderViewSet,
+    ExtractJobSet, ExtractResources, FramePacketBuilder, RenderJobExtractContext, RenderViewSet,
 };
 use rafx_framework::visibility::{DynamicVisibilityNodeSet, StaticVisibilityNodeSet};
 use rafx_framework::{DynResourceAllocatorSet, RenderResources};
@@ -260,23 +259,6 @@ impl Renderer {
             .swapchain_surface_info
             .clone();
 
-        //
-        // Build the frame packet - this takes the views and visibility results and creates a
-        // structure that's used during the extract/prepare/write phases
-        //
-        let frame_packet_builder = {
-            let mut render_node_reservations = RenderNodeReservations::default();
-            for plugin in &*renderer_inner.plugins {
-                plugin.add_render_node_reservations(
-                    &mut render_node_reservations,
-                    extract_resources,
-                    render_resources,
-                );
-            }
-
-            FramePacketBuilder::new(&render_node_reservations)
-        };
-
         let render_view_set = RenderViewSet::default();
 
         //
@@ -302,7 +284,13 @@ impl Renderer {
         //
         // Visibility
         //
+
+        //
+        // Build the frame packet - this takes the views and visibility results and creates a
+        // structure that's used during the extract/prepare/write phases
+        //
         let mut render_views = Vec::default();
+        let frame_packet_builder = FramePacketBuilder::new();
         {
             profiling::scope!("Update visibility");
             let main_view_static_visibility_result =

--- a/rafx-renderer/src/renderer_plugin.rs
+++ b/rafx-renderer/src/renderer_plugin.rs
@@ -5,8 +5,8 @@ use rafx_assets::distill_impl::AssetResource;
 use rafx_assets::AssetManager;
 use rafx_base::resource_map::ResourceMap;
 use rafx_framework::nodes::{
-    ExtractJob, ExtractResources, FramePacketBuilder, RenderNodeReservations,
-    RenderRegistryBuilder, RenderView, RenderViewSet,
+    ExtractJob, ExtractResources, FramePacketBuilder, RenderRegistryBuilder, RenderView,
+    RenderViewSet,
 };
 use rafx_framework::visibility::{DynamicVisibilityNodeSet, StaticVisibilityNodeSet};
 use rafx_framework::RenderResources;
@@ -58,14 +58,6 @@ pub trait RendererPlugin: Send + Sync {
     // ) -> RafxResult<()> {
     //     Ok(())
     // }
-
-    fn add_render_node_reservations(
-        &self,
-        _render_node_reservations: &mut RenderNodeReservations,
-        _extract_resources: &ExtractResources,
-        _render_resources: &RenderResources,
-    ) {
-    }
 
     fn add_render_views(
         &self,

--- a/rafx/examples/nodes_api_design/nodes_api_design.rs
+++ b/rafx/examples/nodes_api_design/nodes_api_design.rs
@@ -1,9 +1,7 @@
 use crate::demo_phases::*;
 use glam::Vec3;
 use legion::*;
-use rafx::nodes::{
-    ExtractJobSet, FramePacketBuilder, RenderNodeReservations, RenderPhaseMaskBuilder,
-};
+use rafx::nodes::{ExtractJobSet, FramePacketBuilder, RenderPhaseMaskBuilder};
 use rafx::nodes::{ExtractResources, RenderViewSet};
 use rafx::nodes::{
     RenderJobExtractContext, RenderJobPrepareContext, RenderJobWriteContext, RenderRegistryBuilder,
@@ -254,10 +252,7 @@ fn main() {
             let frame_packet_builder = {
                 let mut demo_render_nodes = resources.get_mut::<DemoRenderNodeSet>().unwrap();
                 demo_render_nodes.update();
-                let mut all_render_nodes = RenderNodeReservations::default();
-                all_render_nodes.add_reservation(&*demo_render_nodes);
-
-                FramePacketBuilder::new(&all_render_nodes)
+                FramePacketBuilder::new()
             };
 
             // After these jobs end, user calls functions to start jobs that extract data


### PR DESCRIPTION
This removes a callback on plugins that will probably seem strange to end-users. The performance benefit of pre-sizing the vector is not much (0.01ms if that) and I think it would be more accurately implemented anyways by looking at how many nodes were used in the previous frame + some extra %.