### PR TITLE
`ManySprites` and `rafxmark` examples

### DIFF
--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -17,7 +17,7 @@ type-uuid = "0.1"
 sdl2 = { version = "0.34", features = ["raw-window-handle"] }
 imgui = { version = "0.7", optional = true }
 imgui-sdl2 = { version = "0.14.0", optional = true }
-legion = { version = "0.4.0", default-features = false, features = ["serialize"] }
+legion = { version = "0.4.0", default-features = false, features = ["serialize", "codegen"] }
 image = "0.23.12"
 image2 = { version = "0.11", features = ["ser"] }
 

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -17,7 +17,7 @@ type-uuid = "0.1"
 sdl2 = { version = "0.34", features = ["raw-window-handle"] }
 imgui = { version = "0.7", optional = true }
 imgui-sdl2 = { version = "0.14.0", optional = true }
-legion = { version = "0.4.0", default-features = false, features = ["serialize", "codegen"] }
+legion = { version = "0.4.0", default-features = false, features = ["serialize"] }
 image = "0.23.12"
 image2 = { version = "0.11", features = ["ser"] }
 

--- a/demo/src/features/sprite/mod.rs
+++ b/demo/src/features/sprite/mod.rs
@@ -91,9 +91,9 @@ pub fn create_sprite_extract_job() -> Box<dyn ExtractJob> {
 pub struct SpriteRenderNode {
     pub position: glam::Vec3,
     pub tint: glam::Vec3,
-    pub scale: f32,
+    pub scale: glam::Vec2,
     pub alpha: f32,
-    pub rotation: f32,
+    pub rotation: glam::Quat,
     pub image: Handle<ImageAsset>,
 }
 
@@ -156,8 +156,8 @@ rafx::declare_render_feature!(SpriteRenderFeature, SPRITE_FEATURE_INDEX);
 pub(self) struct ExtractedSpriteData {
     position: glam::Vec3,
     texture_size: glam::Vec2,
-    scale: f32,
-    rotation: f32,
+    scale: glam::Vec2,
+    rotation: glam::Quat,
     color: glam::Vec4,
     image_view: ResourceArc<ImageViewResource>,
 }

--- a/demo/src/features/sprite/prepare.rs
+++ b/demo/src/features/sprite/prepare.rs
@@ -54,7 +54,7 @@ impl PrepareJob for SpritePrepareJob {
             let layout = &self.sprite_material.get_raw().descriptor_set_layouts
                 [shaders::sprite_vert::UNIFORM_BUFFER_DESCRIPTOR_SET_INDEX];
             let descriptor_set = descriptor_set_allocator
-                .create_descriptor_set(
+                .create_descriptor_set_with_writer(
                     &*layout,
                     shaders::sprite_vert::DescriptorSet0Args {
                         uniform_buffer: &shaders::sprite_vert::ArgsUniform {
@@ -122,7 +122,7 @@ impl PrepareJob for SpritePrepareJob {
                         .entry(sprite.image_view.clone())
                         .or_insert_with(|| {
                             let descriptor_set = descriptor_set_allocator
-                                .create_descriptor_set(
+                                .create_descriptor_set_with_writer(
                                     &descriptor_set_layouts
                                         [shaders::sprite_frag::TEX_DESCRIPTOR_SET_INDEX],
                                     shaders::sprite_frag::DescriptorSet1Args {
@@ -268,11 +268,11 @@ impl PrepareJob for SpritePrepareJob {
 
                             let matrix = glam::Mat4::from_scale_rotation_translation(
                                 glam::Vec3::new(
-                                    sprite.texture_size.x() * sprite.scale,
-                                    sprite.texture_size.y() * sprite.scale,
+                                    sprite.texture_size.x() * sprite.scale.x(),
+                                    sprite.texture_size.y() * sprite.scale.y(),
                                     1.0,
                                 ),
-                                glam::Quat::from_rotation_z(sprite.rotation),
+                                sprite.rotation,
                                 sprite.position,
                             );
 

--- a/demo/src/features/text/prepare.rs
+++ b/demo/src/features/text/prepare.rs
@@ -170,16 +170,16 @@ impl<'a> PrepareJob for TextPrepareJobImpl {
         // TODO: Submit separate nodes for transparency/text positioned in 3d
         //
         for view in views {
+            let mut view_submit_nodes =
+                ViewSubmitNodes::new(self.feature_index(), view.render_phase_mask());
             for (i, draw_call) in draw_vertices_result.draw_call_metas.iter().enumerate() {
-                let mut view_submit_nodes =
-                    ViewSubmitNodes::new(self.feature_index(), view.render_phase_mask());
                 view_submit_nodes.add_submit_node::<UiRenderPhase>(
                     i as u32,
                     0,
                     draw_call.z_position,
                 );
-                submit_nodes.add_submit_nodes_for_view(view, view_submit_nodes);
             }
+            submit_nodes.add_submit_nodes_for_view(view, view_submit_nodes);
         }
 
         let writer = Box::new(TextCommandWriter {

--- a/demo/src/scenes/many_sprites_scene.rs
+++ b/demo/src/scenes/many_sprites_scene.rs
@@ -11,7 +11,7 @@ use crate::time::TimeState;
 use crate::RenderOptions;
 use glam::{Quat, Vec2, Vec3};
 use legion;
-use legion::{IntoQuery, Read, Resources, Schedule, SystemBuilder, World};
+use legion::{IntoQuery, Read, Resources, Schedule, SystemBuilder, World, Write};
 use rafx::assets::distill_impl::AssetResource;
 use rafx::assets::ImageAsset;
 use rafx::distill::loader::handle::Handle;
@@ -22,12 +22,60 @@ use rand::Rng;
 
 const CAMERA_SPEED: f32 = 1000.0;
 
-pub(super) struct ManySpritesScene {
-    sprite_count: usize,
-    font: Handle<FontAsset>,
-    schedule: Schedule,
-    position: Transform,
+#[derive(Clone, Copy)]
+struct CameraComponent {
+    position: TransformComponent,
     up: Vec3,
+}
+
+#[derive(Clone)]
+struct TextComponent {
+    text: String,
+    font: Handle<FontAsset>,
+}
+
+#[derive(Clone, Copy)]
+struct TransformComponent {
+    pub translation: Vec3,
+    pub rotation: Quat,
+    pub scale: Vec3,
+}
+
+impl TransformComponent {
+    pub fn rotate(
+        &mut self,
+        rotation: Quat,
+    ) {
+        self.rotation *= rotation;
+    }
+
+    pub fn mul_transform(
+        &self,
+        transform: TransformComponent,
+    ) -> Self {
+        let translation = self.mul_vec3(transform.translation);
+        let rotation = self.rotation * transform.rotation;
+        let scale = self.scale * transform.scale;
+        TransformComponent {
+            translation,
+            rotation,
+            scale,
+        }
+    }
+
+    pub fn mul_vec3(
+        &self,
+        mut value: Vec3,
+    ) -> Vec3 {
+        value = self.rotation * value;
+        value = self.scale * value;
+        value += self.translation;
+        value
+    }
+}
+
+pub(super) struct ManySpritesScene {
+    schedule: Schedule,
 }
 
 impl ManySpritesScene {
@@ -56,6 +104,17 @@ impl ManySpritesScene {
         let half_x = (map_size.x() / 2.0) as i32;
         let half_y = (map_size.y() / 2.0) as i32;
 
+        let update_camera_system = SystemBuilder::new("update_camera")
+            .read_resource::<TimeState>()
+            .write_resource::<ViewportsResource>()
+            .with_query(<Write<CameraComponent>>::query())
+            .build(move |_, world, (time_state, viewports_resource), queries| {
+                profiling::scope!("update_camera_system");
+                for camera in queries.iter_mut(world) {
+                    update_main_view_2d(camera, time_state, viewports_resource);
+                }
+            });
+
         let update_render_node_system = SystemBuilder::new("update_render_node")
             .read_resource::<TimeState>()
             .write_resource::<SpriteRenderNodeSet>()
@@ -70,8 +129,26 @@ impl ManySpritesScene {
                 }
             });
 
+        let print_text_system = SystemBuilder::new("print_text")
+            .write_resource::<TextResource>()
+            .with_query(<Read<TextComponent>>::query())
+            .build(move |_, world, text_resource, queries| {
+                profiling::scope!("print_text_system");
+                for text in queries.iter_mut(world) {
+                    text_resource.add_text(
+                        text.text.clone(),
+                        glam::Vec3::new(25.0, 25.0, 0.0),
+                        &text.font,
+                        40.0,
+                        glam::Vec4::new(1.0, 0.0, 0.0, 1.0),
+                    );
+                }
+            });
+
         let schedule = Schedule::builder()
+            .add_system(update_camera_system)
             .add_system(update_render_node_system)
+            .add_system(print_text_system)
             .build();
 
         let mut sprite_count = 0 as usize;
@@ -126,136 +203,21 @@ impl ManySpritesScene {
 
         const CAMERA_Z: f32 = 1000.0;
 
-        let position = Transform {
-            translation: Vec3::new(0., 0., CAMERA_Z),
-            rotation: Quat::from_rotation_x(0.),
-            scale: Vec3::new(1., 1., 1.),
-        };
+        world.push((CameraComponent {
+            position: TransformComponent {
+                translation: Vec3::new(0., 0., CAMERA_Z),
+                rotation: Quat::from_rotation_x(0.),
+                scale: Vec3::new(1., 1., 1.),
+            },
+            up: Vec3::new(0., 1., 0.),
+        },));
 
-        let up = Vec3::new(0., 1., 0.);
-
-        ManySpritesScene {
-            sprite_count,
-            schedule,
+        world.push((TextComponent {
+            text: format!("Sprite Count: {}", sprite_count),
             font,
-            position,
-            up,
-        }
-    }
+        },));
 
-    #[profiling::function]
-    fn update_main_view_2d(
-        &mut self,
-        time: &TimeState,
-        viewports_resource: &mut ViewportsResource,
-    ) {
-        let main_camera_render_phase_mask = RenderPhaseMaskBuilder::default()
-            .add_render_phase::<DepthPrepassRenderPhase>()
-            .add_render_phase::<OpaqueRenderPhase>()
-            .add_render_phase::<TransparentRenderPhase>()
-            .add_render_phase::<UiRenderPhase>()
-            .build();
-
-        // Round to a whole number
-
-        self.position
-            .rotate(Quat::from_rotation_z(time.previous_update_dt() * 0.75));
-        self.position = self.position.mul_transform(Transform {
-            translation: Vec3::new(1., 0., 0.) * CAMERA_SPEED * time.previous_update_dt(),
-            rotation: Quat::from_rotation_x(0.),
-            scale: Vec3::new(1., 1., 1.),
-        });
-
-        let mut eye = self.position.translation;
-
-        let mut transform = Transform {
-            translation: eye,
-            rotation: Quat::from_rotation_x(0.),
-            scale: Vec3::new(1., 1., 1.),
-        };
-
-        transform.rotate(Quat::from_rotation_z(time.previous_update_dt() / 2.0));
-
-        self.up = transform.mul_vec3(self.up);
-
-        let half_width = viewports_resource.main_window_size.width as f32 / 2.0;
-        let half_height = viewports_resource.main_window_size.height as f32 / 2.0;
-
-        //
-        // This logic ensures pixel-perfect rendering when we have odd-sized width/height dimensions.
-        // We also need to round x/y to whole numbers to render pixel-perfect
-        //
-        if viewports_resource.main_window_size.width % 2 != 0 {
-            eye.set_x(eye.x().round() + 0.5);
-        } else {
-            eye.set_x(eye.x().round());
-        }
-
-        if viewports_resource.main_window_size.height % 2 != 0 {
-            eye.set_y(eye.y().round() + 0.5);
-        } else {
-            eye.set_y(eye.y().round());
-        }
-
-        let view = glam::Mat4::look_at_rh(eye, Vec3::new(0., 0., 0.), self.up);
-
-        let proj = glam::Mat4::orthographic_rh(
-            -half_width,
-            half_width,
-            -half_height,
-            half_height,
-            2000.0,
-            0.0,
-        );
-
-        viewports_resource.main_view_meta = Some(RenderViewMeta {
-            eye_position: eye,
-            view,
-            proj,
-            depth_range: RenderViewDepthRange::new_infinite_reverse(0.0),
-            render_phase_mask: main_camera_render_phase_mask,
-            debug_name: "main".to_string(),
-        });
-    }
-}
-
-#[derive(Clone, Copy)]
-struct Transform {
-    pub translation: Vec3,
-    pub rotation: Quat,
-    pub scale: Vec3,
-}
-
-impl Transform {
-    pub fn rotate(
-        &mut self,
-        rotation: Quat,
-    ) {
-        self.rotation *= rotation;
-    }
-
-    pub fn mul_transform(
-        &self,
-        transform: Transform,
-    ) -> Self {
-        let translation = self.mul_vec3(transform.translation);
-        let rotation = self.rotation * transform.rotation;
-        let scale = self.scale * transform.scale;
-        Transform {
-            translation,
-            rotation,
-            scale,
-        }
-    }
-
-    pub fn mul_vec3(
-        &self,
-        mut value: Vec3,
-    ) -> Vec3 {
-        value = self.rotation * value;
-        value = self.scale * value;
-        value += self.translation;
-        value
+        ManySpritesScene { schedule }
     }
 }
 
@@ -265,23 +227,82 @@ impl super::TestScene for ManySpritesScene {
         world: &mut World,
         resources: &mut Resources,
     ) {
-        {
-            let time_state = resources.get::<TimeState>().unwrap();
-            let mut viewports_resource = resources.get_mut::<ViewportsResource>().unwrap();
-            self.update_main_view_2d(&time_state, &mut *viewports_resource);
-        }
-
         self.schedule.execute(world, resources);
-
-        {
-            let mut text_resource = resources.get_mut::<TextResource>().unwrap();
-            text_resource.add_text(
-                format!("Sprite Count: {}", self.sprite_count),
-                glam::Vec3::new(25.0, 25.0, 0.0),
-                &self.font,
-                40.0,
-                glam::Vec4::new(1.0, 0.0, 0.0, 1.0),
-            );
-        }
     }
+}
+
+#[profiling::function]
+fn update_main_view_2d(
+    camera: &mut CameraComponent,
+    time: &TimeState,
+    viewports_resource: &mut ViewportsResource,
+) {
+    let main_camera_render_phase_mask = RenderPhaseMaskBuilder::default()
+        .add_render_phase::<DepthPrepassRenderPhase>()
+        .add_render_phase::<OpaqueRenderPhase>()
+        .add_render_phase::<TransparentRenderPhase>()
+        .add_render_phase::<UiRenderPhase>()
+        .build();
+
+    // Round to a whole number
+
+    camera
+        .position
+        .rotate(Quat::from_rotation_z(time.previous_update_dt() * 0.75));
+    camera.position = camera.position.mul_transform(TransformComponent {
+        translation: Vec3::new(1., 0., 0.) * CAMERA_SPEED * time.previous_update_dt(),
+        rotation: Quat::from_rotation_x(0.),
+        scale: Vec3::new(1., 1., 1.),
+    });
+
+    let mut eye = camera.position.translation;
+
+    let mut transform = TransformComponent {
+        translation: eye,
+        rotation: Quat::from_rotation_x(0.),
+        scale: Vec3::new(1., 1., 1.),
+    };
+
+    transform.rotate(Quat::from_rotation_z(time.previous_update_dt() / 2.0));
+
+    camera.up = transform.mul_vec3(camera.up);
+
+    let half_width = viewports_resource.main_window_size.width as f32 / 2.0;
+    let half_height = viewports_resource.main_window_size.height as f32 / 2.0;
+
+    //
+    // This logic ensures pixel-perfect rendering when we have odd-sized width/height dimensions.
+    // We also need to round x/y to whole numbers to render pixel-perfect
+    //
+    if viewports_resource.main_window_size.width % 2 != 0 {
+        eye.set_x(eye.x().round() + 0.5);
+    } else {
+        eye.set_x(eye.x().round());
+    }
+
+    if viewports_resource.main_window_size.height % 2 != 0 {
+        eye.set_y(eye.y().round() + 0.5);
+    } else {
+        eye.set_y(eye.y().round());
+    }
+
+    let view = glam::Mat4::look_at_rh(eye, Vec3::new(0., 0., 0.), camera.up);
+
+    let proj = glam::Mat4::orthographic_rh(
+        -half_width,
+        half_width,
+        -half_height,
+        half_height,
+        2000.0,
+        0.0,
+    );
+
+    viewports_resource.main_view_meta = Some(RenderViewMeta {
+        eye_position: eye,
+        view,
+        proj,
+        depth_range: RenderViewDepthRange::new_infinite_reverse(0.0),
+        render_phase_mask: main_camera_render_phase_mask,
+        debug_name: "main".to_string(),
+    });
 }

--- a/demo/src/scenes/many_sprites_scene.rs
+++ b/demo/src/scenes/many_sprites_scene.rs
@@ -1,3 +1,5 @@
+// NOTE(dvd): Inspired by Bevy `many_sprites` example (MIT licensed) https://github.com/bevyengine/bevy/blob/621cba4864fd5d2c0962151b126769eff45797fd/examples/2d/many_sprites.rs
+
 use crate::assets::font::FontAsset;
 use crate::components::{PositionComponent, SpriteComponent};
 use crate::features::sprite::{SpriteRenderNode, SpriteRenderNodeSet};
@@ -9,7 +11,7 @@ use crate::time::TimeState;
 use crate::RenderOptions;
 use glam::{Quat, Vec2, Vec3};
 use legion;
-use legion::{SystemBuilder, IntoQuery, Read, Resources, Schedule, World};
+use legion::{IntoQuery, Read, Resources, Schedule, SystemBuilder, World};
 use rafx::assets::distill_impl::AssetResource;
 use rafx::assets::ImageAsset;
 use rafx::distill::loader::handle::Handle;
@@ -61,10 +63,10 @@ impl ManySpritesScene {
             .build(move |_, world, (time, sprite_render_node_set), queries| {
                 profiling::scope!("update_render_node_system");
                 for sprite in queries.iter_mut(world) {
-                    let render_node : &mut SpriteRenderNode = sprite_render_node_set
-                        .get_mut(&sprite.render_node)
-                        .unwrap();
-                    render_node.rotation *= Quat::from_rotation_z(time.previous_update_dt() * rand::random::<f32>());
+                    let render_node: &mut SpriteRenderNode =
+                        sprite_render_node_set.get_mut(&sprite.render_node).unwrap();
+                    render_node.rotation *=
+                        Quat::from_rotation_z(time.previous_update_dt() * rand::random::<f32>());
                 }
             });
 

--- a/demo/src/scenes/many_sprites_scene.rs
+++ b/demo/src/scenes/many_sprites_scene.rs
@@ -1,0 +1,269 @@
+use crate::assets::font::FontAsset;
+use crate::components::{PositionComponent, SpriteComponent};
+use crate::features::sprite::{SpriteRenderNode, SpriteRenderNodeSet};
+use crate::features::text::TextResource;
+use crate::phases::{
+    DepthPrepassRenderPhase, OpaqueRenderPhase, TransparentRenderPhase, UiRenderPhase,
+};
+use crate::time::TimeState;
+use crate::RenderOptions;
+use glam::{Quat, Vec2, Vec3};
+use legion;
+use legion::{Resources, Schedule, World};
+use rafx::assets::distill_impl::AssetResource;
+use rafx::assets::ImageAsset;
+use rafx::distill::loader::handle::Handle;
+use rafx::nodes::{RenderPhaseMaskBuilder, RenderViewDepthRange};
+use rafx::renderer::{RenderViewMeta, ViewportsResource};
+use rafx::visibility::{DynamicAabbVisibilityNode, DynamicVisibilityNodeSet};
+use rand::Rng;
+
+const CAMERA_SPEED: f32 = 1000.0;
+
+pub(super) struct ManySpritesScene {
+    sprite_count: usize,
+    font: Handle<FontAsset>,
+    schedule: Schedule,
+    position: Transform,
+    up: Vec3,
+}
+
+impl ManySpritesScene {
+    pub(super) fn new(
+        world: &mut World,
+        resources: &Resources,
+    ) -> Self {
+        let mut render_options = resources.get_mut::<RenderOptions>().unwrap();
+        *render_options = RenderOptions::default_2d();
+
+        let sprite_image = {
+            let asset_resource = resources.get::<AssetResource>().unwrap();
+            asset_resource.load_asset_path::<ImageAsset, _>("textures/texture-tiny-rust.jpeg")
+        };
+
+        let font = {
+            let asset_resource = resources.get::<AssetResource>().unwrap();
+            asset_resource.load_asset_path::<FontAsset, _>("fonts/mplus-1p-regular.ttf")
+        };
+
+        let mut rng = rand::thread_rng();
+
+        let tile_size = Vec2::splat(64.0);
+        let map_size = Vec2::splat(320.0);
+
+        let half_x = (map_size.x() / 2.0) as i32;
+        let half_y = (map_size.y() / 2.0) as i32;
+
+        let schedule = Schedule::builder().build();
+
+        let mut sprite_count = 0 as usize;
+
+        for y in -half_y..half_y {
+            for x in -half_x..half_x {
+                let position = Vec2::new(x as f32, y as f32);
+                let translation = (position * tile_size).extend(rng.gen::<f32>());
+                let scale = Vec2::new(rng.gen::<f32>() * 2.0, rng.gen::<f32>() * 2.0);
+
+                let tint = super::random_color(&mut rng);
+                let alpha = f32::max(0.2, rng.gen::<f32>());
+
+                let mut sprite_render_nodes = resources.get_mut::<SpriteRenderNodeSet>().unwrap();
+                let mut dynamic_visibility_node_set =
+                    resources.get_mut::<DynamicVisibilityNodeSet>().unwrap();
+
+                let render_node = sprite_render_nodes.register_sprite(SpriteRenderNode {
+                    position: translation,
+                    scale,
+                    rotation: Quat::from_rotation_ypr(
+                        rng.gen::<f32>(),
+                        rng.gen::<f32>(),
+                        rng.gen::<f32>(),
+                    ),
+                    tint,
+                    alpha,
+                    image: sprite_image.clone(),
+                });
+
+                let aabb_info = DynamicAabbVisibilityNode {
+                    handle: render_node.as_raw_generic_handle(),
+                };
+
+                let visibility_node = dynamic_visibility_node_set.register_dynamic_aabb(aabb_info);
+
+                let position_component = PositionComponent {
+                    position: translation,
+                };
+                let sprite_component = SpriteComponent {
+                    render_node,
+                    visibility_node,
+                    alpha,
+                    image: sprite_image.clone(),
+                };
+
+                world.extend((0..1).map(|_| (position_component, sprite_component.clone())));
+
+                sprite_count += 1;
+            }
+        }
+
+        const CAMERA_Z: f32 = 1000.0;
+
+        let position = Transform {
+            translation: Vec3::new(0., 0., CAMERA_Z),
+            rotation: Quat::from_rotation_x(0.),
+            scale: Vec3::new(1., 1., 1.),
+        };
+
+        let up = Vec3::new(0., 1., 0.);
+
+        ManySpritesScene {
+            sprite_count,
+            schedule,
+            font,
+            position,
+            up,
+        }
+    }
+
+    #[profiling::function]
+    fn update_main_view_2d(
+        &mut self,
+        time: &TimeState,
+        viewports_resource: &mut ViewportsResource,
+    ) {
+        let main_camera_render_phase_mask = RenderPhaseMaskBuilder::default()
+            .add_render_phase::<DepthPrepassRenderPhase>()
+            .add_render_phase::<OpaqueRenderPhase>()
+            .add_render_phase::<TransparentRenderPhase>()
+            .add_render_phase::<UiRenderPhase>()
+            .build();
+
+        // Round to a whole number
+
+        self.position
+            .rotate(Quat::from_rotation_z(time.previous_update_dt() * 0.75));
+        self.position = self.position.mul_transform(Transform {
+            translation: Vec3::new(1., 0., 0.) * CAMERA_SPEED * time.previous_update_dt(),
+            rotation: Quat::from_rotation_x(0.),
+            scale: Vec3::new(1., 1., 1.),
+        });
+
+        let mut eye = self.position.translation;
+
+        let mut transform = Transform {
+            translation: eye,
+            rotation: Quat::from_rotation_x(0.),
+            scale: Vec3::new(1., 1., 1.),
+        };
+
+        transform.rotate(Quat::from_rotation_z(time.previous_update_dt() / 2.0));
+
+        self.up = transform.mul_vec3(self.up);
+
+        let half_width = viewports_resource.main_window_size.width as f32 / 2.0;
+        let half_height = viewports_resource.main_window_size.height as f32 / 2.0;
+
+        //
+        // This logic ensures pixel-perfect rendering when we have odd-sized width/height dimensions.
+        // We also need to round x/y to whole numbers to render pixel-perfect
+        //
+        if viewports_resource.main_window_size.width % 2 != 0 {
+            eye.set_x(eye.x().round() + 0.5);
+        } else {
+            eye.set_x(eye.x().round());
+        }
+
+        if viewports_resource.main_window_size.height % 2 != 0 {
+            eye.set_y(eye.y().round() + 0.5);
+        } else {
+            eye.set_y(eye.y().round());
+        }
+
+        let view = glam::Mat4::look_at_rh(eye, Vec3::new(0., 0., 0.), self.up);
+
+        let proj = glam::Mat4::orthographic_rh(
+            -half_width,
+            half_width,
+            -half_height,
+            half_height,
+            2000.0,
+            0.0,
+        );
+
+        viewports_resource.main_view_meta = Some(RenderViewMeta {
+            eye_position: eye,
+            view,
+            proj,
+            depth_range: RenderViewDepthRange::new_infinite_reverse(0.0),
+            render_phase_mask: main_camera_render_phase_mask,
+            debug_name: "main".to_string(),
+        });
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Transform {
+    pub translation: Vec3,
+    pub rotation: Quat,
+    pub scale: Vec3,
+}
+
+impl Transform {
+    pub fn rotate(
+        &mut self,
+        rotation: Quat,
+    ) {
+        self.rotation *= rotation;
+    }
+
+    pub fn mul_transform(
+        &self,
+        transform: Transform,
+    ) -> Self {
+        let translation = self.mul_vec3(transform.translation);
+        let rotation = self.rotation * transform.rotation;
+        let scale = self.scale * transform.scale;
+        Transform {
+            translation,
+            rotation,
+            scale,
+        }
+    }
+
+    pub fn mul_vec3(
+        &self,
+        mut value: Vec3,
+    ) -> Vec3 {
+        value = self.rotation * value;
+        value = self.scale * value;
+        value += self.translation;
+        value
+    }
+}
+
+impl super::TestScene for ManySpritesScene {
+    fn update(
+        &mut self,
+        world: &mut World,
+        resources: &mut Resources,
+    ) {
+        {
+            let time_state = resources.get::<TimeState>().unwrap();
+            let mut viewports_resource = resources.get_mut::<ViewportsResource>().unwrap();
+            self.update_main_view_2d(&time_state, &mut *viewports_resource);
+        }
+
+        self.schedule.execute(world, resources);
+
+        {
+            let mut text_resource = resources.get_mut::<TextResource>().unwrap();
+            text_resource.add_text(
+                format!("Sprite Count: {}", self.sprite_count),
+                glam::Vec3::new(25.0, 25.0, 0.0),
+                &self.font,
+                40.0,
+                glam::Vec4::new(1.0, 0.0, 0.0, 1.0),
+            );
+        }
+    }
+}

--- a/demo/src/scenes/mod.rs
+++ b/demo/src/scenes/mod.rs
@@ -2,8 +2,10 @@ use crate::components::{
     DirectionalLightComponent, PointLightComponent, PositionComponent, SpotLightComponent,
 };
 use crate::features::debug3d::DebugDraw3DResource;
+use glam::Vec3;
 use legion::IntoQuery;
 use legion::{Read, Resources, World};
+use rand::Rng;
 use sdl2::event::Event;
 
 mod shadows_scene;
@@ -15,14 +17,31 @@ use sprite_scene::SpriteScene;
 mod rafxmark_scene;
 use rafxmark_scene::RafxmarkScene;
 
+mod many_sprites_scene;
+use many_sprites_scene::ManySpritesScene;
+
 #[derive(Copy, Clone, Debug)]
 pub enum Scene {
     Shadows,
     Sprite,
     Rafxmark,
+    ManySprites,
 }
 
-pub const ALL_SCENES: [Scene; 3] = [Scene::Shadows, Scene::Sprite, Scene::Rafxmark];
+pub const ALL_SCENES: [Scene; 4] = [
+    Scene::Shadows,
+    Scene::Sprite,
+    Scene::Rafxmark,
+    Scene::ManySprites,
+];
+
+fn random_color(rng: &mut impl Rng) -> Vec3 {
+    let r = rng.gen_range(0.2, 1.0);
+    let g = rng.gen_range(0.2, 1.0);
+    let b = rng.gen_range(0.2, 1.0);
+    let v = Vec3::new(r, g, b);
+    v.normalize()
+}
 
 fn create_scene(
     scene: Scene,
@@ -33,6 +52,7 @@ fn create_scene(
         Scene::Shadows => Box::new(ShadowsScene::new(world, resources)),
         Scene::Sprite => Box::new(SpriteScene::new(world, resources)),
         Scene::Rafxmark => Box::new(RafxmarkScene::new(world, resources)),
+        Scene::ManySprites => Box::new(ManySpritesScene::new(world, resources)),
     }
 }
 

--- a/demo/src/scenes/mod.rs
+++ b/demo/src/scenes/mod.rs
@@ -4,6 +4,7 @@ use crate::components::{
 use crate::features::debug3d::DebugDraw3DResource;
 use legion::IntoQuery;
 use legion::{Read, Resources, World};
+use sdl2::event::Event;
 
 mod shadows_scene;
 use shadows_scene::ShadowsScene;
@@ -11,13 +12,17 @@ use shadows_scene::ShadowsScene;
 mod sprite_scene;
 use sprite_scene::SpriteScene;
 
+mod rafxmark_scene;
+use rafxmark_scene::RafxmarkScene;
+
 #[derive(Copy, Clone, Debug)]
 pub enum Scene {
     Shadows,
     Sprite,
+    Rafxmark,
 }
 
-pub const ALL_SCENES: [Scene; 2] = [Scene::Shadows, Scene::Sprite];
+pub const ALL_SCENES: [Scene; 3] = [Scene::Shadows, Scene::Sprite, Scene::Rafxmark];
 
 fn create_scene(
     scene: Scene,
@@ -27,6 +32,7 @@ fn create_scene(
     match scene {
         Scene::Shadows => Box::new(ShadowsScene::new(world, resources)),
         Scene::Sprite => Box::new(SpriteScene::new(world, resources)),
+        Scene::Rafxmark => Box::new(RafxmarkScene::new(world, resources)),
     }
 }
 
@@ -37,8 +43,16 @@ pub trait TestScene {
     fn update(
         &mut self,
         world: &mut World,
-        resources: &Resources,
+        resources: &mut Resources,
     );
+
+    fn process_input(
+        &mut self,
+        _world: &mut World,
+        _resources: &Resources,
+        _event: Event,
+    ) {
+    }
 
     fn cleanup(
         &mut self,
@@ -77,6 +91,17 @@ impl SceneManager {
         self.next_scene = Some((self.current_scene_index + 1) % ALL_SCENES.len());
     }
 
+    pub fn process_input(
+        &mut self,
+        world: &mut World,
+        resources: &Resources,
+        event: Event,
+    ) {
+        if let Some(current_scene) = &mut self.current_scene {
+            current_scene.process_input(world, resources, event);
+        }
+    }
+
     pub fn try_create_next_scene(
         &mut self,
         world: &mut World,
@@ -99,7 +124,7 @@ impl SceneManager {
     pub fn update_scene(
         &mut self,
         world: &mut World,
-        resources: &Resources,
+        resources: &mut Resources,
     ) {
         self.current_scene
             .as_mut()

--- a/demo/src/scenes/rafxmark_scene.rs
+++ b/demo/src/scenes/rafxmark_scene.rs
@@ -1,0 +1,312 @@
+use crate::assets::font::FontAsset;
+use crate::components::{PositionComponent, SpriteComponent};
+use crate::features::sprite::{SpriteRenderNode, SpriteRenderNodeSet};
+use crate::features::text::TextResource;
+use crate::phases::{
+    DepthPrepassRenderPhase, OpaqueRenderPhase, TransparentRenderPhase, UiRenderPhase,
+};
+use crate::time::TimeState;
+use crate::RenderOptions;
+use glam::f32::Vec3;
+use legion;
+use legion::{IntoQuery, Read, Resources, Schedule, SystemBuilder, World, Write};
+use rafx::assets::distill_impl::AssetResource;
+use rafx::assets::ImageAsset;
+use rafx::distill::loader::handle::Handle;
+use rafx::nodes::{RenderPhaseMaskBuilder, RenderViewDepthRange};
+use rafx::renderer::{RenderViewMeta, ViewportsResource};
+use rafx::visibility::{DynamicAabbVisibilityNode, DynamicVisibilityNodeSet};
+use rand::Rng;
+use sdl2::event::Event;
+use sdl2::mouse::MouseButton;
+
+const SPRITES_PER_SECOND: u32 = 1000;
+const GRAVITY: f32 = -9.8 * 100.0;
+const MAX_VELOCITY: f32 = 750.;
+const SPRITE_SCALE: f32 = 1.0;
+const HALF_SPRITE_SIZE: f32 = 64. * SPRITE_SCALE * 0.5;
+
+const TOP: f32 = 250.;
+const LEFT: f32 = -450.;
+const BOTTOM: f32 = -250.;
+const RIGHT: f32 = 450.;
+
+#[derive(Copy, Clone)]
+struct BodyComponent {
+    velocity: Vec3,
+}
+
+pub(super) struct RafxmarkScene {
+    is_left_button_down: bool,
+    sprite_count: usize,
+    average_fps: f32,
+    font: Handle<FontAsset>,
+    sprite_image: Handle<ImageAsset>,
+    schedule: Schedule,
+}
+
+impl RafxmarkScene {
+    pub(super) fn new(
+        _world: &mut World,
+        resources: &Resources,
+    ) -> Self {
+        let mut render_options = resources.get_mut::<RenderOptions>().unwrap();
+        *render_options = RenderOptions::default_2d();
+
+        let sprite_image = {
+            let asset_resource = resources.get::<AssetResource>().unwrap();
+            asset_resource.load_asset_path::<ImageAsset, _>("textures/texture-tiny-rust.jpeg")
+        };
+
+        let font = {
+            let asset_resource = resources.get::<AssetResource>().unwrap();
+            asset_resource.load_asset_path::<FontAsset, _>("fonts/mplus-1p-regular.ttf")
+        };
+
+        let gravity_system = SystemBuilder::new("gravity")
+            .read_resource::<TimeState>()
+            .with_query(<Write<BodyComponent>>::query())
+            .build(move |_, world, time, queries| {
+                for body in queries.iter_mut(world) {
+                    body.velocity
+                        .set_y(body.velocity.y() + GRAVITY * time.previous_update_dt());
+                }
+            });
+
+        let velocity_system = SystemBuilder::new("velocity")
+            .read_resource::<TimeState>()
+            .with_query(<(Write<PositionComponent>, Write<BodyComponent>)>::query())
+            .build(move |_, world, time, queries| {
+                for (pos, body) in queries.iter_mut(world) {
+                    pos.position += body.velocity * time.previous_update_dt();
+                }
+            });
+
+        let collision_system = SystemBuilder::new("collision")
+            .with_query(<(Write<PositionComponent>, Write<BodyComponent>)>::query())
+            .build(move |_, world, (), queries| {
+                for (pos, body) in queries.iter_mut(world) {
+                    if pos.position.x() < LEFT {
+                        pos.position.set_x(LEFT);
+                        body.velocity.set_x(-body.velocity.x());
+                    } else if pos.position.x() > RIGHT {
+                        pos.position.set_x(RIGHT);
+                        body.velocity.set_x(-body.velocity.x());
+                    }
+
+                    if pos.position.y() > TOP {
+                        pos.position.set_y(TOP);
+                        body.velocity.set_y(-body.velocity.y());
+                    } else if pos.position.y() < BOTTOM {
+                        pos.position.set_y(BOTTOM);
+                        body.velocity.set_y(-body.velocity.y());
+                    }
+                }
+            });
+
+        let update_render_node_system = SystemBuilder::new("update_render_node")
+            .write_resource::<SpriteRenderNodeSet>()
+            .with_query(<(Write<PositionComponent>, Read<SpriteComponent>)>::query())
+            .build(move |_, world, sprite_render_node_set, queries| {
+                for (pos, sprite) in queries.iter_mut(world) {
+                    sprite_render_node_set
+                        .get_mut(&sprite.render_node)
+                        .unwrap()
+                        .position = pos.position;
+                }
+            });
+
+        let schedule = Schedule::builder()
+            .add_system(gravity_system)
+            .add_system(velocity_system)
+            .add_system(collision_system)
+            .add_system(update_render_node_system)
+            .build();
+
+        RafxmarkScene {
+            is_left_button_down: false,
+            sprite_count: 0,
+            average_fps: 0.0,
+            schedule,
+            sprite_image,
+            font,
+        }
+    }
+
+    fn random_color(rng: &mut impl Rng) -> Vec3 {
+        let r = rng.gen_range(0.2, 1.0);
+        let g = rng.gen_range(0.2, 1.0);
+        let b = rng.gen_range(0.2, 1.0);
+        let v = Vec3::new(r, g, b);
+        v.normalize()
+    }
+
+    fn add_sprites(
+        &mut self,
+        world: &mut World,
+        resources: &Resources,
+    ) {
+        let time = resources.get::<TimeState>().unwrap();
+
+        let spawn_count = (SPRITES_PER_SECOND as f32 * time.previous_update_dt()) as usize;
+
+        let mut rnd = rand::thread_rng();
+        let tint = Self::random_color(&mut rnd);
+
+        let sprite_x = LEFT + HALF_SPRITE_SIZE;
+        let sprite_y = TOP - HALF_SPRITE_SIZE;
+
+        for count in 0..spawn_count {
+            let sprite_z = (self.sprite_count + count) as f32 * 0.00001;
+
+            let velocity = Vec3::new(
+                rand::random::<f32>() * MAX_VELOCITY - (MAX_VELOCITY * 0.5),
+                0.,
+                0.,
+            );
+
+            let position = Vec3::new(sprite_x, sprite_y, 100.0 + sprite_z as f32);
+
+            let alpha = 0.8;
+
+            let mut sprite_render_nodes = resources.get_mut::<SpriteRenderNodeSet>().unwrap();
+            let mut dynamic_visibility_node_set =
+                resources.get_mut::<DynamicVisibilityNodeSet>().unwrap();
+
+            let render_node = sprite_render_nodes.register_sprite(SpriteRenderNode {
+                position,
+                scale: SPRITE_SCALE,
+                rotation: 0.0,
+                tint,
+                alpha,
+                image: self.sprite_image.clone(),
+            });
+
+            let aabb_info = DynamicAabbVisibilityNode {
+                handle: render_node.as_raw_generic_handle(),
+            };
+
+            let visibility_node = dynamic_visibility_node_set.register_dynamic_aabb(aabb_info);
+
+            let position_component = PositionComponent { position };
+            let sprite_component = SpriteComponent {
+                render_node,
+                visibility_node,
+                alpha,
+                image: self.sprite_image.clone(),
+            };
+            let body_component = BodyComponent { velocity };
+
+            world.extend(
+                (0..1).map(|_| (position_component, sprite_component.clone(), body_component)),
+            );
+        }
+
+        self.sprite_count += spawn_count;
+    }
+}
+
+impl super::TestScene for RafxmarkScene {
+    fn update(
+        &mut self,
+        world: &mut World,
+        resources: &mut Resources,
+    ) {
+        {
+            let mut viewports_resource = resources.get_mut::<ViewportsResource>().unwrap();
+            update_main_view_2d(&mut *viewports_resource);
+        }
+
+        if self.is_left_button_down {
+            self.add_sprites(world, resources);
+        }
+
+        self.schedule.execute(world, resources);
+
+        {
+            let mut text_resource = resources.get_mut::<TextResource>().unwrap();
+            text_resource.add_text(
+                format!("Sprite Count: {}", self.sprite_count),
+                glam::Vec3::new(25.0, 25.0, 0.0),
+                &self.font,
+                40.0,
+                glam::Vec4::new(1.0, 1.0, 1.0, 1.0),
+            );
+        }
+    }
+
+    fn process_input(
+        &mut self,
+        _world: &mut World,
+        _resources: &Resources,
+        event: Event,
+    ) {
+        match event {
+            Event::MouseButtonDown { mouse_btn, .. } => {
+                if mouse_btn == MouseButton::Left {
+                    self.is_left_button_down = true;
+                }
+            }
+            Event::MouseButtonUp { mouse_btn, .. } => {
+                if mouse_btn == MouseButton::Left {
+                    self.is_left_button_down = false;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[profiling::function]
+fn update_main_view_2d(viewports_resource: &mut ViewportsResource) {
+    let main_camera_render_phase_mask = RenderPhaseMaskBuilder::default()
+        .add_render_phase::<DepthPrepassRenderPhase>()
+        .add_render_phase::<OpaqueRenderPhase>()
+        .add_render_phase::<TransparentRenderPhase>()
+        .add_render_phase::<UiRenderPhase>()
+        .build();
+
+    const CAMERA_Z: f32 = 1000.0;
+
+    // Round to a whole number
+    let mut eye = Vec3::new(0., 0., CAMERA_Z);
+
+    let half_width = viewports_resource.main_window_size.width as f32 / 2.0;
+    let half_height = viewports_resource.main_window_size.height as f32 / 2.0;
+
+    //
+    // This logic ensures pixel-perfect rendering when we have odd-sized width/height dimensions.
+    // We also need to round x/y to whole numbers to render pixel-perfect
+    //
+    if viewports_resource.main_window_size.width % 2 != 0 {
+        eye.set_x(eye.x().round() + 0.5);
+    } else {
+        eye.set_x(eye.x().round());
+    }
+
+    if viewports_resource.main_window_size.height % 2 != 0 {
+        eye.set_y(eye.y().round() + 0.5);
+    } else {
+        eye.set_y(eye.y().round());
+    }
+
+    let view = glam::Mat4::look_at_rh(eye, Vec3::new(0., 0., 0.), Vec3::new(0.0, 1.0, 0.0));
+
+    let proj = glam::Mat4::orthographic_rh(
+        -half_width,
+        half_width,
+        -half_height,
+        half_height,
+        2000.0,
+        0.0,
+    );
+
+    viewports_resource.main_view_meta = Some(RenderViewMeta {
+        eye_position: eye,
+        view,
+        proj,
+        depth_range: RenderViewDepthRange::new_infinite_reverse(0.0),
+        render_phase_mask: main_camera_render_phase_mask,
+        debug_name: "main".to_string(),
+    });
+}

--- a/demo/src/scenes/rafxmark_scene.rs
+++ b/demo/src/scenes/rafxmark_scene.rs
@@ -1,3 +1,5 @@
+// NOTE(dvd): Inspired by Bevy `bevymark` example (MIT licensed) https://github.com/bevyengine/bevy/blob/81b53d15d4e038261182b8d7c8f65f9a3641fd2d/examples/tools/bevymark.rs
+
 use crate::assets::font::FontAsset;
 use crate::components::{PositionComponent, SpriteComponent};
 use crate::features::sprite::{SpriteRenderNode, SpriteRenderNodeSet};

--- a/demo/src/scenes/rafxmark_scene.rs
+++ b/demo/src/scenes/rafxmark_scene.rs
@@ -11,6 +11,7 @@ use crate::time::TimeState;
 use crate::RenderOptions;
 use glam::{Quat, Vec2, Vec3};
 use legion;
+use legion::systems::CommandBuffer;
 use legion::{IntoQuery, Read, Resources, Schedule, SystemBuilder, World, Write};
 use rafx::assets::distill_impl::AssetResource;
 use rafx::assets::ImageAsset;
@@ -37,17 +38,30 @@ struct BodyComponent {
     velocity: Vec3,
 }
 
-pub(super) struct RafxmarkScene {
-    is_left_button_down: bool,
-    sprite_count: usize,
+#[derive(Clone)]
+struct TextComponent {
+    text: String,
     font: Handle<FontAsset>,
+}
+
+#[derive(Clone, Copy)]
+struct InputComponent {
+    is_left_mouse_button_down: bool,
+}
+
+#[derive(Clone)]
+struct SpriteSpawnerComponent {
+    sprite_count: usize,
     sprite_image: Handle<ImageAsset>,
+}
+
+pub(super) struct RafxmarkScene {
     schedule: Schedule,
 }
 
 impl RafxmarkScene {
     pub(super) fn new(
-        _world: &mut World,
+        world: &mut World,
         resources: &Resources,
     ) -> Self {
         let mut render_options = resources.get_mut::<RenderOptions>().unwrap();
@@ -62,6 +76,45 @@ impl RafxmarkScene {
             let asset_resource = resources.get::<AssetResource>().unwrap();
             asset_resource.load_asset_path::<FontAsset, _>("fonts/mplus-1p-regular.ttf")
         };
+
+        let update_camera_system = SystemBuilder::new("update_camera")
+            .write_resource::<ViewportsResource>()
+            .build(move |_, _, viewports_resource, _| {
+                profiling::scope!("update_camera_system");
+                update_main_view_2d(viewports_resource);
+            });
+
+        let sprite_spawner_system = SystemBuilder::new("sprite_spawner")
+            .read_resource::<TimeState>()
+            .write_resource::<SpriteRenderNodeSet>()
+            .write_resource::<DynamicVisibilityNodeSet>()
+            .with_query(<(
+                Read<InputComponent>,
+                Write<SpriteSpawnerComponent>,
+                Write<TextComponent>,
+            )>::query())
+            .build(
+                move |commands,
+                      world,
+                      (time, sprite_render_nodes, dynamic_visibility_node_set),
+                      queries| {
+                    profiling::scope!("sprite_spawner_system");
+                    for (input, sprite_spawner, sprite_count_text) in queries.iter_mut(world) {
+                        if input.is_left_mouse_button_down {
+                            add_sprites(
+                                sprite_spawner,
+                                commands,
+                                time,
+                                sprite_render_nodes,
+                                dynamic_visibility_node_set,
+                            );
+                        }
+
+                        sprite_count_text.text =
+                            format!("Sprite Count: {}", sprite_spawner.sprite_count);
+                    }
+                },
+            );
 
         let gravity_system = SystemBuilder::new("gravity")
             .read_resource::<TimeState>()
@@ -120,84 +173,47 @@ impl RafxmarkScene {
                 }
             });
 
+        let print_text_system = SystemBuilder::new("print_text")
+            .write_resource::<TextResource>()
+            .with_query(<Read<TextComponent>>::query())
+            .build(move |_, world, text_resource, queries| {
+                profiling::scope!("print_text_system");
+                for text in queries.iter_mut(world) {
+                    text_resource.add_text(
+                        text.text.clone(),
+                        glam::Vec3::new(25.0, 25.0, 0.0),
+                        &text.font,
+                        40.0,
+                        glam::Vec4::new(1.0, 1.0, 1.0, 1.0),
+                    );
+                }
+            });
+
         let schedule = Schedule::builder()
+            .add_system(update_camera_system)
+            .add_system(sprite_spawner_system)
             .add_system(gravity_system)
             .add_system(velocity_system)
             .add_system(collision_system)
             .add_system(update_render_node_system)
+            .add_system(print_text_system)
             .build();
 
-        RafxmarkScene {
-            is_left_button_down: false,
-            sprite_count: 0,
-            schedule,
-            sprite_image,
-            font,
-        }
-    }
+        world.push((
+            TextComponent {
+                text: "".to_string(),
+                font,
+            },
+            InputComponent {
+                is_left_mouse_button_down: false,
+            },
+            SpriteSpawnerComponent {
+                sprite_count: 0,
+                sprite_image,
+            },
+        ));
 
-    fn add_sprites(
-        &mut self,
-        world: &mut World,
-        resources: &Resources,
-    ) {
-        let time = resources.get::<TimeState>().unwrap();
-
-        let spawn_count = (SPRITES_PER_SECOND as f32 * time.previous_update_dt()) as usize;
-
-        let mut rng = rand::thread_rng();
-        let tint = super::random_color(&mut rng);
-
-        let sprite_x = LEFT + HALF_SPRITE_SIZE;
-        let sprite_y = TOP - HALF_SPRITE_SIZE;
-
-        for count in 0..spawn_count {
-            let sprite_z = (self.sprite_count + count) as f32 * 0.00001;
-
-            let velocity = Vec3::new(
-                rand::random::<f32>() * MAX_VELOCITY - (MAX_VELOCITY * 0.5),
-                0.,
-                0.,
-            );
-
-            let position = Vec3::new(sprite_x, sprite_y, 100.0 + sprite_z as f32);
-
-            let alpha = 0.8;
-
-            let mut sprite_render_nodes = resources.get_mut::<SpriteRenderNodeSet>().unwrap();
-            let mut dynamic_visibility_node_set =
-                resources.get_mut::<DynamicVisibilityNodeSet>().unwrap();
-
-            let render_node = sprite_render_nodes.register_sprite(SpriteRenderNode {
-                position,
-                scale: Vec2::splat(SPRITE_SCALE),
-                rotation: Quat::from_rotation_z(0.0),
-                tint,
-                alpha,
-                image: self.sprite_image.clone(),
-            });
-
-            let aabb_info = DynamicAabbVisibilityNode {
-                handle: render_node.as_raw_generic_handle(),
-            };
-
-            let visibility_node = dynamic_visibility_node_set.register_dynamic_aabb(aabb_info);
-
-            let position_component = PositionComponent { position };
-            let sprite_component = SpriteComponent {
-                render_node,
-                visibility_node,
-                alpha,
-                image: self.sprite_image.clone(),
-            };
-            let body_component = BodyComponent { velocity };
-
-            world.extend(
-                (0..1).map(|_| (position_component, sprite_component.clone(), body_component)),
-            );
-        }
-
-        self.sprite_count += spawn_count;
+        RafxmarkScene { schedule }
     }
 }
 
@@ -207,49 +223,91 @@ impl super::TestScene for RafxmarkScene {
         world: &mut World,
         resources: &mut Resources,
     ) {
-        {
-            let mut viewports_resource = resources.get_mut::<ViewportsResource>().unwrap();
-            update_main_view_2d(&mut *viewports_resource);
-        }
-
-        if self.is_left_button_down {
-            self.add_sprites(world, resources);
-        }
-
         self.schedule.execute(world, resources);
-
-        {
-            let mut text_resource = resources.get_mut::<TextResource>().unwrap();
-            text_resource.add_text(
-                format!("Sprite Count: {}", self.sprite_count),
-                glam::Vec3::new(25.0, 25.0, 0.0),
-                &self.font,
-                40.0,
-                glam::Vec4::new(1.0, 1.0, 1.0, 1.0),
-            );
-        }
     }
 
     fn process_input(
         &mut self,
-        _world: &mut World,
+        world: &mut World,
         _resources: &Resources,
         event: Event,
     ) {
+        let mut query = <Write<InputComponent>>::query();
+        let input = query.iter_mut(world).last().unwrap();
         match event {
             Event::MouseButtonDown { mouse_btn, .. } => {
                 if mouse_btn == MouseButton::Left {
-                    self.is_left_button_down = true;
+                    input.is_left_mouse_button_down = true;
                 }
             }
             Event::MouseButtonUp { mouse_btn, .. } => {
                 if mouse_btn == MouseButton::Left {
-                    self.is_left_button_down = false;
+                    input.is_left_mouse_button_down = false;
                 }
             }
             _ => {}
         }
     }
+}
+
+fn add_sprites(
+    sprite_spawner: &mut SpriteSpawnerComponent,
+    commands: &mut CommandBuffer,
+    time: &TimeState,
+    sprite_render_nodes: &mut SpriteRenderNodeSet,
+    dynamic_visibility_node_set: &mut DynamicVisibilityNodeSet,
+) {
+    let spawn_count = (SPRITES_PER_SECOND as f32 * time.previous_update_dt()) as usize;
+
+    let mut rng = rand::thread_rng();
+    let tint = super::random_color(&mut rng);
+
+    let sprite_x = LEFT + HALF_SPRITE_SIZE;
+    let sprite_y = TOP - HALF_SPRITE_SIZE;
+
+    for count in 0..spawn_count {
+        let sprite_z = (sprite_spawner.sprite_count + count) as f32 * 0.00001;
+
+        let velocity = Vec3::new(
+            rand::random::<f32>() * MAX_VELOCITY - (MAX_VELOCITY * 0.5),
+            0.,
+            0.,
+        );
+
+        let position = Vec3::new(sprite_x, sprite_y, 100.0 + sprite_z as f32);
+
+        let alpha = 0.8;
+
+        let render_node = sprite_render_nodes.register_sprite(SpriteRenderNode {
+            position,
+            scale: Vec2::splat(SPRITE_SCALE),
+            rotation: Quat::from_rotation_z(0.0),
+            tint,
+            alpha,
+            image: sprite_spawner.sprite_image.clone(),
+        });
+
+        let aabb_info = DynamicAabbVisibilityNode {
+            handle: render_node.as_raw_generic_handle(),
+        };
+
+        let visibility_node = dynamic_visibility_node_set.register_dynamic_aabb(aabb_info);
+
+        let position_component = PositionComponent { position };
+        let sprite_component = SpriteComponent {
+            render_node,
+            visibility_node,
+            alpha,
+            image: sprite_spawner.sprite_image.clone(),
+        };
+        let body_component = BodyComponent { velocity };
+
+        commands.extend(
+            (0..1).map(move |_| (position_component, sprite_component.clone(), body_component)),
+        );
+    }
+
+    sprite_spawner.sprite_count += spawn_count;
 }
 
 #[profiling::function]

--- a/demo/src/scenes/rafxmark_scene.rs
+++ b/demo/src/scenes/rafxmark_scene.rs
@@ -65,6 +65,7 @@ impl RafxmarkScene {
             .read_resource::<TimeState>()
             .with_query(<Write<BodyComponent>>::query())
             .build(move |_, world, time, queries| {
+                profiling::scope!("gravity_system");
                 for body in queries.iter_mut(world) {
                     body.velocity
                         .set_y(body.velocity.y() + GRAVITY * time.previous_update_dt());
@@ -75,6 +76,7 @@ impl RafxmarkScene {
             .read_resource::<TimeState>()
             .with_query(<(Write<PositionComponent>, Write<BodyComponent>)>::query())
             .build(move |_, world, time, queries| {
+                profiling::scope!("velocity_system");
                 for (pos, body) in queries.iter_mut(world) {
                     pos.position += body.velocity * time.previous_update_dt();
                 }
@@ -83,6 +85,7 @@ impl RafxmarkScene {
         let collision_system = SystemBuilder::new("collision")
             .with_query(<(Write<PositionComponent>, Write<BodyComponent>)>::query())
             .build(move |_, world, (), queries| {
+                profiling::scope!("collision_system");
                 for (pos, body) in queries.iter_mut(world) {
                     if pos.position.x() < LEFT {
                         pos.position.set_x(LEFT);
@@ -106,6 +109,7 @@ impl RafxmarkScene {
             .write_resource::<SpriteRenderNodeSet>()
             .with_query(<(Write<PositionComponent>, Read<SpriteComponent>)>::query())
             .build(move |_, world, sprite_render_node_set, queries| {
+                profiling::scope!("update_render_node_system");
                 for (pos, sprite) in queries.iter_mut(world) {
                     sprite_render_node_set
                         .get_mut(&sprite.render_node)

--- a/demo/src/scenes/shadows_scene.rs
+++ b/demo/src/scenes/shadows_scene.rs
@@ -180,7 +180,7 @@ impl super::TestScene for ShadowsScene {
     fn update(
         &mut self,
         world: &mut World,
-        resources: &Resources,
+        resources: &mut Resources,
     ) {
         super::add_light_debug_draw(&resources, &world);
 

--- a/demo/src/scenes/sprite_scene.rs
+++ b/demo/src/scenes/sprite_scene.rs
@@ -32,8 +32,8 @@ impl SpriteScene {
 
         let sprite_image = {
             let asset_resource = resources.get::<AssetResource>().unwrap();
-            //asset_resource.load_asset_path::<ImageAsset, _>("textures/texture2.jpg")
-            asset_resource.load_asset::<ImageAsset>("cad0eeb3-68e1-48a5-81b6-ba4a7e848f38".into())
+            asset_resource.load_asset_path::<ImageAsset, _>("textures/texture2.jpg")
+            //asset_resource.load_asset::<ImageAsset>("cad0eeb3-68e1-48a5-81b6-ba4a7e848f38".into())
         };
 
         let ldtk_handle = {
@@ -92,7 +92,7 @@ impl super::TestScene for SpriteScene {
     fn update(
         &mut self,
         _world: &mut World,
-        resources: &Resources,
+        resources: &mut Resources,
     ) {
         {
             let time_state = resources.get::<TimeState>().unwrap();

--- a/demo/src/scenes/sprite_scene.rs
+++ b/demo/src/scenes/sprite_scene.rs
@@ -57,8 +57,8 @@ impl SpriteScene {
 
             let render_node = sprite_render_nodes.register_sprite(SpriteRenderNode {
                 position,
-                scale: 0.125,
-                rotation: 0.0,
+                scale: glam::Vec2::splat(0.125),
+                rotation: glam::Quat::from_rotation_z(0.0),
                 tint: glam::Vec3::new(1.0, 1.0, 1.0),
                 alpha,
                 image: sprite_image.clone(),


### PR DESCRIPTION
```
Windows 10
Vulkan Backend
AMD Ryzen 7 5800X
32 GB RAM
Nvidia RTX 3080
```

`ManySprites` is inspired by `Bevy`'s `many_sprites` demo.

![image](https://user-images.githubusercontent.com/4888530/112950335-05927580-90ef-11eb-85d0-35287b57e2dc.png)

![image](https://user-images.githubusercontent.com/4888530/112951526-4c349f80-90f0-11eb-875d-644461bba959.png)

On my machine, I'm seeing ~0.75 FPS in `many_sprites` on `Bevy`, and ~18 FPS in `rafx`. This does not perform any visibility culling. The sprites in `ManySprites` are rotating each frame, the camera is rotating, the view matrix is rotating, the sprites have random colors and scales, the opacities are varied per sprite, and the sprites have random depths. This avoids most perf optimizations that `rafx` has for less degenerate scenes, like batching sprites on the same z-layer.

`rafxmark` is inspired by `Bevy`'s `bevymark` demo.

![image](https://user-images.githubusercontent.com/4888530/112951297-0c6db800-90f0-11eb-9286-381aed1741b1.png)

I can add about ~35k bouncing sprites with velocities / gravity / collisions and remain above 60 FPS. 
In `Bevy`, it tanks at about ~7k.

![image](https://user-images.githubusercontent.com/4888530/112951381-23aca580-90f0-11eb-9f32-628ee1e6573e.png)
