### PR TITLE
Fix for text rendering in the demo

### DIFF
--- a/demo/src/features/text/jobs/write.rs
+++ b/demo/src/features/text/jobs/write.rs
@@ -158,16 +158,26 @@ impl WriteJob for TextWriteJob {
                     &*write_context.command_buffer,
                     rafx_image,
                 )?;
+                write_context.command_buffer.cmd_resource_barrier(
+                    &[],
+                    &[RafxTextureBarrier::state_transition(
+                        rafx_image,
+                        RafxResourceState::COPY_SRC,
+                        RafxResourceState::SHADER_RESOURCE,
+                    )],
+                )?;
             }
-
-            write_context.command_buffer.cmd_resource_barrier(
-                &[],
-                &[RafxTextureBarrier::state_transition(
-                    rafx_image,
-                    RafxResourceState::COPY_DST,
-                    RafxResourceState::SHADER_RESOURCE,
-                )],
-            )?;
+            else
+            {
+                write_context.command_buffer.cmd_resource_barrier(
+                    &[],
+                    &[RafxTextureBarrier::state_transition(
+                        rafx_image,
+                        RafxResourceState::COPY_DST,
+                        RafxResourceState::SHADER_RESOURCE,
+                    )],
+                )?;
+            }
         }
 
         Ok(())

--- a/demo/src/features/text/jobs/write.rs
+++ b/demo/src/features/text/jobs/write.rs
@@ -158,17 +158,6 @@ impl WriteJob for TextWriteJob {
                     &*write_context.command_buffer,
                     rafx_image,
                 )?;
-                write_context.command_buffer.cmd_resource_barrier(
-                    &[],
-                    &[RafxTextureBarrier {
-                        texture: &rafx_image,
-                        src_state: RafxResourceState::COPY_SRC,
-                        dst_state: RafxResourceState::SHADER_RESOURCE,
-                        queue_transition: RafxBarrierQueueTransition::None,
-                        array_slice: None,
-                        mip_slice: Some(0),
-                    }],
-                )?;
             }
 
             write_context.command_buffer.cmd_resource_barrier(

--- a/demo/src/features/text/jobs/write.rs
+++ b/demo/src/features/text/jobs/write.rs
@@ -25,8 +25,8 @@ lazy_static::lazy_static! {
 
 use super::TextImageUpdate;
 use rafx::api::{
-    RafxCmdCopyBufferToTextureParams, RafxIndexBufferBinding, RafxIndexType, RafxResourceState,
-    RafxBarrierQueueTransition, RafxTextureBarrier, RafxVertexBufferBinding,
+    RafxBarrierQueueTransition, RafxCmdCopyBufferToTextureParams, RafxIndexBufferBinding,
+    RafxIndexType, RafxResourceState, RafxTextureBarrier, RafxVertexBufferBinding,
 };
 use rafx::framework::{BufferResource, DescriptorSetArc, MaterialPassResource, ResourceArc};
 use rafx::nodes::{push_view_indexed_value, RenderJobBeginExecuteGraphContext, RenderViewIndex};

--- a/demo/src/features/text/jobs/write.rs
+++ b/demo/src/features/text/jobs/write.rs
@@ -166,9 +166,7 @@ impl WriteJob for TextWriteJob {
                         RafxResourceState::SHADER_RESOURCE,
                     )],
                 )?;
-            }
-            else
-            {
+            } else {
                 write_context.command_buffer.cmd_resource_barrier(
                     &[],
                     &[RafxTextureBarrier::state_transition(


### PR DESCRIPTION
The smaller text in the demo looks borked, like this (windows/vulkan):

![image](https://user-images.githubusercontent.com/283519/115768820-77d73c80-a3b3-11eb-8060-ba0f0f246483.png)
![image](https://user-images.githubusercontent.com/283519/115777627-34360000-a3be-11eb-883a-ae4ff4d256a4.png)

I found the issue on fontdue (mooman219/fontdue#60) but then I observed the problem was very intermittent, and certainly not just "off by 1 pixel" (or maybe that's a different problem). Adding a 1 sec delay before first attempt to draw text fixed it, but for a 0.2 sec delay it was "almost fixed". So I guessed it's about lack of sync during GPU upload. Hardcoding 1 mip level for the atlas also fixed it. So I looked how mipmaps are generated in the other place (image upload) and noticed there are some barriers for mip level 0 before calling `generate_mipmaps`, so I added them here as well and now it works. Maybe these barriers should be added by `generate_mipmaps` itself.

![image](https://user-images.githubusercontent.com/283519/115770246-2039d080-a3b5-11eb-876c-7cd3dc762ea4.png)

This was a great learning experience! Thank you very much for making this library, it is exactly what I need.