### PR TITLE
Change destroying resource after its manager unwrap to expect

### DIFF
--- a/rafx-framework/src/resources/resource_arc.rs
+++ b/rafx-framework/src/resources/resource_arc.rs
@@ -50,9 +50,8 @@ where
     ResourceT: Clone,
 {
     fn drop(&mut self) {
-        if self.drop_tx.send(self.resource.clone()).is_err() {
-            log::warn!("A resource was dropped after the resource manager was destroyed, it might not clean up properly")
-        }
+        self.drop_tx.send(self.resource.clone())
+            .expect("A resource was dropped after the resource manager was destroyed, it might not clean up properly");
     }
 }
 

--- a/rafx-framework/src/resources/resource_arc.rs
+++ b/rafx-framework/src/resources/resource_arc.rs
@@ -50,7 +50,9 @@ where
     ResourceT: Clone,
 {
     fn drop(&mut self) {
-        self.drop_tx.send(self.resource.clone()).unwrap();
+        if self.drop_tx.send(self.resource.clone()).is_err() {
+            log::warn!("A resource was dropped after the resource manager was destroyed, it might not clean up properly")
+        }
     }
 }
 


### PR DESCRIPTION
@DavidVonDerau have any thoughts on this? I think we could either make it a log (non-fatal, but likely happening when the program is shutting down anyways) or an expect() which would be fatal but still give more clarity than a simple unwrap. There is already helpful warning spam when the resource manager gets shut down early. I'm usually happy to fail fast and loud but given this is happening when the program is likely already shutting down, I don't mind relaxing it a bit.

This is based on #126 