### PR TITLE
Limited support for `const` in the shader processor

### DIFF
--- a/demo/shaders/glsl/mesh_pbr_frag.glsl
+++ b/demo/shaders/glsl/mesh_pbr_frag.glsl
@@ -21,12 +21,6 @@ layout (location = 6) in mat3 in_model_view;
 
 const float PI = 3.14159265359;
 
-//TODO: Shader processor can't handle consts
-//const int MAX_POINT_LIGHTS = 16;
-//const int MAX_DIRECTIONAL_LIGHTS = 16;
-//const int MAX_SPOT_LIGHTS = 16;
-//const int MAX_SHADOWS = MAX_DIRECTIONAL_LIGHTS * MAX_POINT_LIGHTS * MAX_SPOT_LIGHTS;
-
 // These are determined by trial and error. A deeper Z projection requires lower numbers here so this may need to be
 // per light based on Z-depth
 //

--- a/demo/shaders/glsl/mesh_pbr_uniform.glsl
+++ b/demo/shaders/glsl/mesh_pbr_uniform.glsl
@@ -48,6 +48,16 @@ struct ShadowMapCubeData {
     float cube_map_projection_far_z;
 };
 
+const int MAX_POINT_LIGHTS = 16;
+const int MAX_DIRECTIONAL_LIGHTS = 16;
+const int MAX_SPOT_LIGHTS = 16;
+
+const int MAX_SHADOW_MAPS_2D = MAX_DIRECTIONAL_LIGHTS + MAX_SPOT_LIGHTS;
+const int SHADOW_MAP_2D_ARRAY_LEN = 32; // TODO(dvd): Shader processor can't handle const math in array indices.
+
+const int MAX_SHADOW_MAPS_CUBE = MAX_POINT_LIGHTS;
+const int SHADOW_MAP_CUBE_ARRAY_LEN = MAX_POINT_LIGHTS;
+
 // @[export]
 // @[internal_buffer]
 layout (set = 0, binding = 0) uniform PerViewData {
@@ -57,11 +67,11 @@ layout (set = 0, binding = 0) uniform PerViewData {
     uint point_light_count;
     uint directional_light_count;
     uint spot_light_count;
-    PointLight point_lights[16];
-    DirectionalLight directional_lights[16];
-    SpotLight spot_lights[16];
-    ShadowMap2DData shadow_map_2d_data[32];
-    ShadowMapCubeData shadow_map_cube_data[16];
+    PointLight point_lights[MAX_POINT_LIGHTS];
+    DirectionalLight directional_lights[MAX_DIRECTIONAL_LIGHTS];
+    SpotLight spot_lights[MAX_SPOT_LIGHTS];
+    ShadowMap2DData shadow_map_2d_data[SHADOW_MAP_2D_ARRAY_LEN];
+    ShadowMapCubeData shadow_map_cube_data[SHADOW_MAP_CUBE_ARRAY_LEN];
 } per_view_data;
 
 // @[immutable_samplers([
@@ -93,10 +103,10 @@ layout (set = 0, binding = 1) uniform sampler smp;
 layout (set = 0, binding = 2) uniform sampler smp_depth;
 
 // @[export]
-layout (set = 0, binding = 3) uniform texture2D shadow_map_images[32];
+layout (set = 0, binding = 3) uniform texture2D shadow_map_images[SHADOW_MAP_2D_ARRAY_LEN];
 
 // @[export]
-layout (set = 0, binding = 4) uniform textureCube shadow_map_images_cube[16];
+layout (set = 0, binding = 4) uniform textureCube shadow_map_images_cube[SHADOW_MAP_CUBE_ARRAY_LEN];
 
 //
 // Per-Material Bindings

--- a/demo/shaders/src/bloom_combine_frag.rs
+++ b/demo/shaders/src/bloom_combine_frag.rs
@@ -10,6 +10,31 @@ use rafx_framework::{
     ResourceArc,
 };
 
+pub const FP16_SCALE: f32 = 0.0009765625f32;
+pub const APERTURE_F_NUMBER: f32 = 0.01f32;
+pub const ISO: f32 = 1.0f32;
+pub const SHUTTER_SPEED_VALUE: f32 = 1.0f32;
+pub const KEY_VALUE: f32 = 0.1150f32;
+pub const MANUAL_EXPOSURE: f32 = -16.0f32;
+pub const WHITE_POINT_HABLE: f32 = 6.0f32;
+pub const WHITE_POINT_HEJL: f32 = 1.0f32;
+pub const EXPOSURE_MODE_AUTO: i32 = 1;
+pub const EXPOSURE_MODE_MANUAL_SBS: i32 = 2;
+pub const EXPOSURE_MODE_MANUAL_SOS: i32 = 3;
+pub const EXPOSURE_MODE: i32 = EXPOSURE_MODE_MANUAL_SBS;
+pub const SHOULDER_STRENGTH: f32 = 4.0f32;
+pub const LINEAR_STRENGTH: f32 = 5.0f32;
+pub const LINEAR_ANGLE: f32 = 0.1200f32;
+pub const TOE_STRENGTH: f32 = 13.0f32;
+pub const TM_STEPHEN_HILL_ACES: i32 = 1;
+pub const TM_SIMPLIFIED_LUMA_ACES: i32 = 2;
+pub const TM_HEJL2015: i32 = 3;
+pub const TM_HABLE: i32 = 4;
+pub const TM_FILMIC_ALU: i32 = 5;
+pub const TM_LOG_DERIVATIVE: i32 = 6;
+pub const TM_VISUALIZE_RGB_MAX: i32 = 7;
+pub const TM_VISUALIZE_LUMA: i32 = 8;
+
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct ConfigStd140 {

--- a/demo/shaders/src/mesh_textured_frag.rs
+++ b/demo/shaders/src/mesh_textured_frag.rs
@@ -10,6 +10,19 @@ use rafx_framework::{
     ResourceArc,
 };
 
+pub const MAX_POINT_LIGHTS: i32 = 16;
+pub const MAX_DIRECTIONAL_LIGHTS: i32 = 16;
+pub const MAX_SPOT_LIGHTS: i32 = 16;
+pub const MAX_SHADOW_MAPS_2D: i32 = MAX_DIRECTIONAL_LIGHTS + MAX_SPOT_LIGHTS;
+pub const SHADOW_MAP_2D_ARRAY_LEN: i32 = 32;
+pub const MAX_SHADOW_MAPS_CUBE: i32 = MAX_POINT_LIGHTS;
+pub const SHADOW_MAP_CUBE_ARRAY_LEN: i32 = MAX_POINT_LIGHTS;
+pub const PI: f32 = 3.14159265359f32;
+pub const SPOT_LIGHT_SHADOW_MAP_BIAS_MULTIPLIER: f32 = 0.4f32;
+pub const DIRECTIONAL_LIGHT_SHADOW_MAP_BIAS_MULTIPLIER: f32 = 1.0f32;
+pub const SHADOW_MAP_BIAS_MAX: f32 = 0.01f32;
+pub const SHADOW_MAP_BIAS_MIN: f32 = 0.0005f32;
+
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct ShadowMap2DDataStd140 {

--- a/demo/shaders/src/mesh_textured_vert.rs
+++ b/demo/shaders/src/mesh_textured_vert.rs
@@ -10,6 +10,14 @@ use rafx_framework::{
     ResourceArc,
 };
 
+pub const MAX_POINT_LIGHTS: i32 = 16;
+pub const MAX_DIRECTIONAL_LIGHTS: i32 = 16;
+pub const MAX_SPOT_LIGHTS: i32 = 16;
+pub const MAX_SHADOW_MAPS_2D: i32 = MAX_DIRECTIONAL_LIGHTS + MAX_SPOT_LIGHTS;
+pub const SHADOW_MAP_2D_ARRAY_LEN: i32 = 32;
+pub const MAX_SHADOW_MAPS_CUBE: i32 = MAX_POINT_LIGHTS;
+pub const SHADOW_MAP_CUBE_ARRAY_LEN: i32 = MAX_POINT_LIGHTS;
+
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct ShadowMap2DDataStd140 {

--- a/demo/shaders/src/mesh_untextured_frag.rs
+++ b/demo/shaders/src/mesh_untextured_frag.rs
@@ -10,6 +10,19 @@ use rafx_framework::{
     ResourceArc,
 };
 
+pub const MAX_POINT_LIGHTS: i32 = 16;
+pub const MAX_DIRECTIONAL_LIGHTS: i32 = 16;
+pub const MAX_SPOT_LIGHTS: i32 = 16;
+pub const MAX_SHADOW_MAPS_2D: i32 = MAX_DIRECTIONAL_LIGHTS + MAX_SPOT_LIGHTS;
+pub const SHADOW_MAP_2D_ARRAY_LEN: i32 = 32;
+pub const MAX_SHADOW_MAPS_CUBE: i32 = MAX_POINT_LIGHTS;
+pub const SHADOW_MAP_CUBE_ARRAY_LEN: i32 = MAX_POINT_LIGHTS;
+pub const PI: f32 = 3.14159265359f32;
+pub const SPOT_LIGHT_SHADOW_MAP_BIAS_MULTIPLIER: f32 = 0.4f32;
+pub const DIRECTIONAL_LIGHT_SHADOW_MAP_BIAS_MULTIPLIER: f32 = 1.0f32;
+pub const SHADOW_MAP_BIAS_MAX: f32 = 0.01f32;
+pub const SHADOW_MAP_BIAS_MIN: f32 = 0.0005f32;
+
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct ShadowMap2DDataStd140 {

--- a/demo/shaders/src/mesh_untextured_vert.rs
+++ b/demo/shaders/src/mesh_untextured_vert.rs
@@ -10,6 +10,14 @@ use rafx_framework::{
     ResourceArc,
 };
 
+pub const MAX_POINT_LIGHTS: i32 = 16;
+pub const MAX_DIRECTIONAL_LIGHTS: i32 = 16;
+pub const MAX_SPOT_LIGHTS: i32 = 16;
+pub const MAX_SHADOW_MAPS_2D: i32 = MAX_DIRECTIONAL_LIGHTS + MAX_SPOT_LIGHTS;
+pub const SHADOW_MAP_2D_ARRAY_LEN: i32 = 32;
+pub const MAX_SHADOW_MAPS_CUBE: i32 = MAX_POINT_LIGHTS;
+pub const SHADOW_MAP_CUBE_ARRAY_LEN: i32 = MAX_POINT_LIGHTS;
+
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct ShadowMap2DDataStd140 {

--- a/demo/src/features/mesh/internal/frame_packet.rs
+++ b/demo/src/features/mesh/internal/frame_packet.rs
@@ -10,6 +10,13 @@ use std::sync::Arc;
 
 pub struct MeshRenderFeatureTypes;
 
+pub const MAX_DIRECTIONAL_LIGHTS: usize =
+    shaders::mesh_textured_frag::MAX_DIRECTIONAL_LIGHTS as usize;
+pub const MAX_POINT_LIGHTS: usize = shaders::mesh_textured_frag::MAX_POINT_LIGHTS as usize;
+pub const MAX_SPOT_LIGHTS: usize = shaders::mesh_textured_frag::MAX_SPOT_LIGHTS as usize;
+pub const MAX_SHADOW_MAPS_2D: usize = shaders::mesh_textured_frag::MAX_SHADOW_MAPS_2D as usize;
+pub const MAX_SHADOW_MAPS_CUBE: usize = shaders::mesh_textured_frag::MAX_SHADOW_MAPS_CUBE as usize;
+
 //---------
 // EXTRACT
 //---------
@@ -29,9 +36,9 @@ pub struct MeshRenderObjectInstanceData {
 
 #[derive(Default)]
 pub struct MeshPerViewData {
-    pub directional_lights: [Option<ExtractedDirectionalLight>; 16],
-    pub point_lights: [Option<ExtractedPointLight>; 16],
-    pub spot_lights: [Option<ExtractedSpotLight>; 16],
+    pub directional_lights: [Option<ExtractedDirectionalLight>; MAX_DIRECTIONAL_LIGHTS],
+    pub point_lights: [Option<ExtractedPointLight>; MAX_POINT_LIGHTS],
+    pub spot_lights: [Option<ExtractedSpotLight>; MAX_SPOT_LIGHTS],
     pub num_directional_lights: u32,
     pub num_point_lights: u32,
     pub num_spot_lights: u32,
@@ -67,10 +74,6 @@ pub type MeshViewPacket = ViewPacket<MeshRenderFeatureTypes>;
 //---------
 // PREPARE
 //---------
-
-//TODO: Pull this const from the shader
-pub const MAX_SHADOW_MAPS_2D: usize = 32;
-pub const MAX_SHADOW_MAPS_CUBE: usize = 16;
 
 pub struct MeshPartDescriptorSetPair {
     pub depth_descriptor_set: DescriptorSetArc,


### PR DESCRIPTION
The shader processor now supports exporting `const` values into the generated Rust code and the usage of `const` values for array sizes.

There are some limitations.

- The shader processor can recognize `*`, `-`, `/`, `+` for the purpose of exporting `const` values but it cannot do so if the const math would be needed to evaluate an array size.
- `const` values that are a `mat3`, `mat4`, `vec3`, or `vec4` will not be exported.

When evaluating an array size, the shader processor will recursively follow `const` values until either a `usize` value is found or one of the above limitations is reached.