### PR TITLE
Fixed egui clip rects not being scaled for highdpi

### DIFF
--- a/demo/src/features/egui/internal/egui_draw_data.rs
+++ b/demo/src/features/egui/internal/egui_draw_data.rs
@@ -31,14 +31,23 @@ impl EguiDrawData {
         let mut all_clipped_draw_calls = Vec::default();
 
         for clipped_mesh in clipped_meshes {
-            let rect = clipped_mesh.0;
-            let meshes = clipped_mesh.1.split_to_u16();
-
+            let min = clipped_mesh.0.min;
+            let max = clipped_mesh.0.max;
             let mut clipped_draw_calls = EguiClippedDrawCalls {
-                clip_rect: rect,
+                clip_rect: egui::Rect::from_min_max(
+                    egui::Pos2 {
+                        x: min.x * pixels_per_point as f32,
+                        y: min.y * pixels_per_point as f32,
+                    },
+                    egui::Pos2 {
+                        x: max.x * pixels_per_point as f32,
+                        y: max.y * pixels_per_point as f32,
+                    },
+                ),
                 draw_calls: vec![],
             };
 
+            let meshes = clipped_mesh.1.split_to_u16();
             for mut mesh in meshes {
                 let vertex_offset = vertices.len();
                 let index_offset = indices.len();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/283519/120346554-2308d900-c304-11eb-82af-b1a425d294b9.png)

Initially I though it might be due to `egui_winit_platform` (I use `winit` in my project) since the demo seemed fine, just the ui a little blurry. But then I noticed that, for some reason, SDL seems to ignore completely highdpi on my machine, and this was why it appeared to work (the whole thing is blurry, not just egui).

So I looked into how `egui_winit_ash_vk_mem` does egui integration and found that they [scale the clip rects by dpi](https://github.com/MatchaChoco010/egui_winit_ash_vk_mem/blob/main/src/lib.rs#L990), so I did the same here and it worked.

Still don't know why SDL ignores `allow_highdpi()`. I think I installed the bundled one, maybe it has features disabled or something.