### PR TITLE
Remove usage of std::time::Instant

### DIFF
--- a/demo-web/src/lib.rs
+++ b/demo-web/src/lib.rs
@@ -363,7 +363,7 @@ pub fn update_loop(
         })?;
 
         log::trace!("Starting event loop");
-        let start_time = instant::Instant::now();
+        let start_time = rafx::base::Instant::now();
 
         event_loop.run(move |event, _, control_flow| {
             *control_flow = ControlFlow::Poll;

--- a/demo/src/features/egui/internal/egui_manager.rs
+++ b/demo/src/features/egui/internal/egui_manager.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 struct EguiManagerInner {
     context: egui::CtxRef,
     raw_input: egui::RawInput,
-    start_time: std::time::Instant,
+    start_time: rafx::base::Instant,
 
     // This is produced when calling render()
     font_atlas: Option<Arc<egui::Texture>>,
@@ -99,7 +99,7 @@ impl EguiManager {
             inner: Arc::new(Mutex::new(EguiManagerInner {
                 context: ctx,
                 raw_input,
-                start_time: std::time::Instant::now(),
+                start_time: rafx::base::Instant::now(),
                 font_atlas: None,
                 clipped_meshes: None,
             })),

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -329,7 +329,7 @@ pub fn run(args: &DemoArgs) -> RafxResult<()> {
     'running: loop {
         profiling::scope!("Main Loop");
 
-        let t0 = std::time::Instant::now();
+        let t0 = rafx::base::Instant::now();
 
         //
         // Update time
@@ -526,7 +526,7 @@ pub fn run(args: &DemoArgs) -> RafxResult<()> {
             egui_manager.end_frame();
         }
 
-        let t1 = std::time::Instant::now();
+        let t1 = rafx::base::Instant::now();
         log::trace!(
             "[main] Simulation took {} ms",
             (t1 - t0).as_secs_f32() * 1000.0
@@ -587,7 +587,7 @@ pub fn run(args: &DemoArgs) -> RafxResult<()> {
                 .unwrap();
         }
 
-        let t2 = std::time::Instant::now();
+        let t2 = rafx::base::Instant::now();
         log::trace!(
             "[main] start rendering took {} ms",
             (t2 - t1).as_secs_f32() * 1000.0

--- a/rafx-api/src/extra/swapchain_helper.rs
+++ b/rafx-api/src/extra/swapchain_helper.rs
@@ -253,11 +253,11 @@ impl RafxSwapchainHelper {
         self.wait_until_previous_frame_submitted()?;
 
         if let Some(shared_state) = self.shared_state.take() {
-            let begin_wait_time = std::time::Instant::now();
+            let begin_wait_time = rafx_base::Instant::now();
             while Arc::strong_count(&shared_state) > 1 {
                 // It's possible the previous frame has not finished dropping. Wait until this
                 // occurs.
-                if (std::time::Instant::now() - begin_wait_time).as_secs_f32() > 1.0 {
+                if (rafx_base::Instant::now() - begin_wait_time).as_secs_f32() > 1.0 {
                     // Bail early, we won't properly clean up
                     log::error!("A presentable frame was submitted but still isn't dropped. Can't clean up the swapchain");
                     break;

--- a/rafx-assets/src/assets/asset_manager.rs
+++ b/rafx-assets/src/assets/asset_manager.rs
@@ -154,10 +154,10 @@ impl AssetManager {
 
         fn on_interval<F: Fn()>(
             interval: std::time::Duration,
-            last_time: &mut Option<std::time::Instant>,
+            last_time: &mut Option<rafx_base::Instant>,
             f: F,
         ) {
-            let now = std::time::Instant::now();
+            let now = rafx_base::Instant::now();
 
             if last_time.is_none() || now - last_time.unwrap() >= interval {
                 (f)();
@@ -180,6 +180,7 @@ impl AssetManager {
                             asset_handle
                         );
                     });
+                    #[cfg(not(target_arch = "wasm32"))]
                     std::thread::sleep(std::time::Duration::from_millis(1));
                 }
                 LoadStatus::Loading => {
@@ -190,8 +191,8 @@ impl AssetManager {
                             asset_handle
                         );
                     });
+                    #[cfg(not(target_arch = "wasm32"))]
                     std::thread::sleep(std::time::Duration::from_millis(1));
-                    // keep waiting
                 }
                 LoadStatus::Loaded => {
                     break Ok(());

--- a/rafx-assets/src/assets/upload.rs
+++ b/rafx-assets/src/assets/upload.rs
@@ -141,7 +141,7 @@ struct InProgressUploadInner {
 
 struct InProgressUploadDebugInfo {
     upload_id: usize,
-    start_time: std::time::Instant,
+    start_time: rafx_base::Instant,
     size: u64,
     image_count: usize,
     buffer_count: usize,
@@ -537,7 +537,7 @@ impl UploadQueue {
                 buffer_count: in_flight_buffer_uploads.len(),
                 image_count: in_flight_image_uploads.len(),
                 size: upload.bytes_written(),
-                start_time: std::time::Instant::now(),
+                start_time: rafx_base::Instant::now(),
             };
 
             self.uploads_in_progress.push(InProgressUpload::new(
@@ -570,7 +570,7 @@ impl UploadQueue {
                         debug_info.size,
                         debug_info.image_count,
                         debug_info.buffer_count,
-                        (std::time::Instant::now() - debug_info.start_time).as_secs_f32(),
+                        debug_info.start_time.elapsed().as_secs_f32(),
                         debug_info.upload_id
                     );
 
@@ -585,7 +585,7 @@ impl UploadQueue {
                         debug_info.size,
                         debug_info.image_count,
                         debug_info.buffer_count,
-                        (std::time::Instant::now() - debug_info.start_time).as_secs_f32(),
+                        debug_info.start_time.elapsed().as_secs_f32(),
                         debug_info.upload_id
                     );
 
@@ -659,7 +659,7 @@ impl UploadManager {
 
         let generate_mips = request.asset.generate_mips_at_runtime;
 
-        let t0 = std::time::Instant::now();
+        let t0 = rafx_base::Instant::now();
         let image_data = match request.asset.format {
             ImageAssetDataFormat::RawRGBA32 => GpuImageData::new_simple(
                 request.asset.width,
@@ -754,7 +754,7 @@ impl UploadManager {
                 GpuImageData::new(layers, rafx_format)
             }
         };
-        let t1 = std::time::Instant::now();
+        let t1 = rafx_base::Instant::now();
 
         #[cfg(debug_assertions)]
         image_data.verify_state();

--- a/rafx-assets/src/distill_impl/asset_storage.rs
+++ b/rafx-assets/src/distill_impl/asset_storage.rs
@@ -495,7 +495,7 @@ impl<AssetT: TypeUuid + 'static + Send> DynAssetStorage for Storage<AssetT> {
         let asset = match uncommitted_asset_state.result {
             UpdateAssetResult::Result(asset) => asset,
             UpdateAssetResult::AsyncResult(rx) => rx
-                .recv_timeout(std::time::Duration::from_secs(0))
+                .try_recv()
                 .expect("LoadOp committed but result not sent via channel"),
         };
 

--- a/rafx-base/Cargo.toml
+++ b/rafx-base/Cargo.toml
@@ -18,3 +18,9 @@ log = "0.4"
 fnv = "1.0"
 crossbeam-channel = "0.5"
 downcast-rs = "1.2.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+instant = { version = "0.1", features = ["wasm-bindgen"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+instant = { version = "0.1" }

--- a/rafx-base/src/lib.rs
+++ b/rafx-base/src/lib.rs
@@ -20,3 +20,5 @@ pub mod atomic_once_cell_array;
 pub mod atomic_once_cell_stack;
 
 pub mod owned_pool;
+
+pub use instant::Instant;

--- a/rafx-renderer/src/render_frame_job.rs
+++ b/rafx-renderer/src/render_frame_job.rs
@@ -30,7 +30,7 @@ impl RenderFrameJob {
         presentable_frame: RafxPresentableFrame,
         render_resources: &RenderResources,
     ) -> RenderFrameJobResult {
-        let t0 = std::time::Instant::now();
+        let t0 = rafx_base::Instant::now();
 
         let mut thread_pool = {
             let mut renderer_inner = self.renderer.inner.lock().unwrap();
@@ -49,7 +49,7 @@ impl RenderFrameJob {
             &mut *thread_pool,
         );
 
-        let t1 = std::time::Instant::now();
+        let t1 = rafx_base::Instant::now();
         log::trace!(
             "[render thread] render took {} ms",
             (t1 - t0).as_secs_f32() * 1000.0
@@ -71,7 +71,7 @@ impl RenderFrameJob {
             }
         }
 
-        let t2 = std::time::Instant::now();
+        let t2 = rafx_base::Instant::now();
         log::trace!(
             "[render thread] present took {} ms",
             (t2 - t1).as_secs_f32() * 1000.0
@@ -92,7 +92,7 @@ impl RenderFrameJob {
         feature_plugins: Arc<Vec<Arc<dyn RenderFeaturePlugin>>>,
         thread_pool: &mut dyn RendererThreadPool,
     ) -> RafxResult<Vec<DynCommandBuffer>> {
-        let t0 = std::time::Instant::now();
+        let t0 = rafx_base::Instant::now();
 
         //
         // Prepare Jobs - everything beyond this point could be done in parallel with the main thread
@@ -138,7 +138,7 @@ impl RenderFrameJob {
             (submit_node_blocks, frame_and_submit_packets)
         };
 
-        let t1 = std::time::Instant::now();
+        let t1 = rafx_base::Instant::now();
         log::trace!(
             "[render thread] render prepare took {} ms",
             (t1 - t0).as_secs_f32() * 1000.0
@@ -168,7 +168,7 @@ impl RenderFrameJob {
             }
         };
 
-        let t2 = std::time::Instant::now();
+        let t2 = rafx_base::Instant::now();
         log::trace!(
             "[render thread] execute graph took {} ms",
             (t2 - t1).as_secs_f32() * 1000.0

--- a/rafx-renderer/src/renderer.rs
+++ b/rafx-renderer/src/renderer.rs
@@ -202,7 +202,7 @@ impl Renderer {
         //
         // Block until the previous frame completes being submitted to GPU
         //
-        let t0 = std::time::Instant::now();
+        let t0 = rafx_base::Instant::now();
 
         let presentable_frame = {
             let viewports_resource = extract_resources.fetch::<ViewportsResource>();
@@ -223,7 +223,7 @@ impl Renderer {
             .render_thread
             .wait_for_render_finish(std::time::Duration::from_secs(30));
 
-        let t1 = std::time::Instant::now();
+        let t1 = rafx_base::Instant::now();
         log::trace!(
             "[main] wait for previous frame present {} ms",
             (t1 - t0).as_secs_f32() * 1000.0


### PR DESCRIPTION
Also remove other usages of time-based abstractions that aren't available in wasm