### PR TITLE
Dependency updates

### DIFF
--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-rafx = { path = "../rafx", features = ["renderer"] }
+rafx = { path = "../rafx", features = ["renderer", "basis-universal"] }
 shaders = { path = "shaders" }
 distill = { version = "=0.0.3", features = ["serde_importers"] }
 uuid = "0.8"
@@ -17,16 +17,14 @@ type-uuid = "0.1"
 sdl2 = { version = "0.34", features = ["raw-window-handle"] }
 imgui = { version = "0.7", optional = true }
 imgui-sdl2 = { version = "0.14.0", optional = true }
-egui = { version = "0.12", features = ["default_fonts"] }
+egui = { version = "0.12", features = ["default_fonts"], optional = true }
 puffin_egui = { version = "0.2.0", optional = true }
 legion = { version = "0.4.0", default-features = false, features = ["serialize"] }
 image = "0.23.12"
-image2 = { version = "0.11", features = ["ser"] }
 
 # GLTF asset type
 # for https://github.com/gltf-rs/gltf/pull/288
-#gltf = "0.15"
-gltf = { git = "https://github.com/gltf-rs/gltf.git", rev = "e49aef5ee7b40c2c8f8a50efaed36b97bbb52bd4" }
+gltf = "0.16"
 
 # Font asset type
 fontdue = "0.4"
@@ -43,8 +41,8 @@ glam = { version = "0.13.1", features = [ "serde" ] }
 arrayvec = "0.5"
 crossbeam-channel = "0.5"
 fnv = "1.0"
-rand = "0.7.3"
-pcg_rand = "0.11.1"
+rand = "0.8"
+pcg_rand = "0.13"
 itertools = "0.8"
 mopa = "0.2"
 lazy_static = "1"
@@ -61,13 +59,15 @@ bevy_tasks = "0.5.0"
 default = [
     "sdl2-bundled",
     "sdl2-static-link",
-    "profile-with-puffin",
-    #"profile-with-stats-alloc", # Cannot be enabled with "profile-with-tracy-memory". Will run renderer / game loop single-threaded.
+    #"profile-with-puffin",
+    #"egui"
+    #"stats_alloc", # Cannot be enabled with "profile-with-tracy-memory". Will run renderer / game loop single-threaded.
     #"profile-with-optick",
     #"profile-with-tracy",
     #"profile-with-tracy-memory", # Cannot be enabled with "profile-with-stats-alloc".
     #"profile-with-superluminal"
 ]
+basis-universal = ["rafx/basis-universal"]
 use-imgui = ["imgui", "imgui-sdl2"]
 rafx-empty = ["rafx/rafx-empty"]
 rafx-vulkan = ["rafx/rafx-vulkan"]
@@ -80,7 +80,8 @@ static-vulkan = ["rafx/static-vulkan"]
 profile-with-stats-alloc = ["stats_alloc", "rafx/no-render-thread"]
 profile-with-puffin = [
     "profiling/profile-with-puffin",
-    "puffin_egui"
+    "puffin_egui",
+    "egui"
 ]
 profile-with-optick = [
     "profiling/profile-with-optick",

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -59,8 +59,8 @@ bevy_tasks = "0.5.0"
 default = [
     "sdl2-bundled",
     "sdl2-static-link",
-    #"profile-with-puffin",
-    #"egui"
+    "profile-with-puffin",
+    "egui"
     #"stats_alloc", # Cannot be enabled with "profile-with-tracy-memory". Will run renderer / game loop single-threaded.
     #"profile-with-optick",
     #"profile-with-tracy",

--- a/demo/cli/Cargo.toml
+++ b/demo/cli/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 demo = { path = ".." }
-rafx = { path = "../../rafx", features = ["renderer"] }
+rafx = { path = "../../rafx", features = ["renderer", "basis-universal"] }
 log = "0.4"
 env_logger = "0.6"
 distill = { version = "=0.0.3", features = ["serde_importers"] }

--- a/demo/src/assets/gltf/importer.rs
+++ b/demo/src/assets/gltf/importer.rs
@@ -176,7 +176,7 @@ impl Importer for GltfImporter {
     where
         Self: Sized,
     {
-        26
+        27
     }
 
     fn version(&self) -> u32 {
@@ -677,7 +677,8 @@ fn extract_materials_to_import(
             material.normal_texture().map_or(1.0, |x| x.scale());
         material_asset.material_data.occlusion_texture_strength =
             material.occlusion_texture().map_or(1.0, |x| x.strength());
-        material_asset.material_data.alpha_cutoff = material.alpha_cutoff();
+        // Default is 0.5 per GLTF specification
+        material_asset.material_data.alpha_cutoff = material.alpha_cutoff().unwrap_or(0.5);
 
         material_asset.base_color_texture = pbr_metallic_roughness
             .base_color_texture()

--- a/demo/src/features/mod.rs
+++ b/demo/src/features/mod.rs
@@ -5,6 +5,7 @@ pub mod sprite;
 pub mod text;
 pub mod tile_layer;
 
+#[cfg(feature = "egui")]
 pub mod egui;
 
 #[cfg(feature = "use-imgui")]

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -32,6 +32,7 @@ mod demo_plugin;
 mod demo_renderer_thread_pool;
 
 use crate::assets::font::FontAsset;
+#[cfg(feature = "egui")]
 use crate::features::egui::{EguiContextResource, Sdl2EguiManager};
 use crate::features::text::TextResource;
 use crate::features::tile_layer::TileLayerResource;
@@ -197,6 +198,7 @@ impl RenderOptions {
 }
 
 impl RenderOptions {
+    #[cfg(feature = "egui")]
     pub fn ui(
         &mut self,
         ui: &mut egui::Ui,
@@ -406,6 +408,7 @@ pub fn run(args: &DemoArgs) -> RafxResult<()> {
         //
         // Notify egui of frame begin
         //
+        #[cfg(feature = "egui")]
         {
             let egui_manager = resources.get::<Sdl2EguiManager>().unwrap();
             egui_manager.begin_frame(&sdl2_systems.window)?;
@@ -427,6 +430,7 @@ pub fn run(args: &DemoArgs) -> RafxResult<()> {
             scene_manager.update_scene(&mut world, &mut resources);
         }
 
+        #[cfg(feature = "egui")]
         {
             let ctx = resources.get::<EguiContextResource>().unwrap().context();
             let time_state = resources.get::<TimeState>().unwrap();
@@ -521,6 +525,7 @@ pub fn run(args: &DemoArgs) -> RafxResult<()> {
         //
         // Close egui input for this frame
         //
+        #[cfg(feature = "egui")]
         {
             let egui_manager = resources.get::<Sdl2EguiManager>().unwrap();
             egui_manager.end_frame();
@@ -578,6 +583,8 @@ pub fn run(args: &DemoArgs) -> RafxResult<()> {
                 debug_draw_3d_resource
             );
             add_to_extract_resources!(crate::features::text::TextResource, text_resource);
+
+            #[cfg(feature = "egui")]
             add_to_extract_resources!(crate::features::egui::Sdl2EguiManager, sdl2_egui_manager);
 
             extract_resources.insert(&mut world);
@@ -605,13 +612,20 @@ fn process_input(
     resources: &Resources,
     event_pump: &mut sdl2::EventPump,
 ) -> bool {
+    #[cfg(feature = "egui")]
     let egui_manager = resources
         .get::<crate::features::egui::Sdl2EguiManager>()
         .unwrap();
 
     for event in event_pump.poll_iter() {
-        egui_manager.handle_event(&event);
-        let ignore_event = egui_manager.ignore_event(&event);
+        #[cfg(not(feature = "egui"))]
+        let ignore_event = false;
+
+        #[cfg(feature = "egui")]
+        let ignore_event = {
+            egui_manager.handle_event(&event);
+            egui_manager.ignore_event(&event)
+        };
 
         if !ignore_event {
             //log::trace!("{:?}", event);

--- a/demo/src/scenes/many_cubes_scene.rs
+++ b/demo/src/scenes/many_cubes_scene.rs
@@ -5,6 +5,7 @@ use crate::components::{
     MeshComponent, PointLightComponent, TransformComponent, VisibilityComponent,
 };
 use crate::features::debug3d::Debug3DRenderFeature;
+#[cfg(feature = "egui")]
 use crate::features::egui::EguiRenderFeature;
 use crate::features::mesh::{
     MeshNoShadowsRenderFeatureFlag, MeshRenderFeature, MeshRenderObject, MeshRenderObjectSet,
@@ -82,8 +83,8 @@ impl ManyCubesScene {
         for _ in 0..NUM_CUBES {
             let transform_component = TransformComponent {
                 translation: glam::Vec3::new(
-                    rng.gen_range(-50.0, 50.0),
-                    rng.gen_range(-50.0, 50.0),
+                    rng.gen_range(-50.0..50.0),
+                    rng.gen_range(-50.0..50.0),
                     0.0,
                 ),
                 scale: glam::Vec3::new(0.5, 0.5, 0.5),
@@ -197,9 +198,13 @@ fn update_main_view_3d(
         .add_render_phase::<WireframeRenderPhase>()
         .add_render_phase::<UiRenderPhase>();
 
-    let mut feature_mask_builder = RenderFeatureMaskBuilder::default()
-        .add_render_feature::<MeshRenderFeature>()
-        .add_render_feature::<EguiRenderFeature>();
+    let mut feature_mask_builder =
+        RenderFeatureMaskBuilder::default().add_render_feature::<MeshRenderFeature>();
+
+    #[cfg(feature = "egui")]
+    {
+        feature_mask_builder = feature_mask_builder.add_render_feature::<EguiRenderFeature>();
+    }
 
     if render_options.show_text {
         feature_mask_builder = feature_mask_builder.add_render_feature::<TextRenderFeature>();

--- a/demo/src/scenes/many_sprites_scene.rs
+++ b/demo/src/scenes/many_sprites_scene.rs
@@ -2,7 +2,6 @@
 
 use crate::assets::font::FontAsset;
 use crate::components::{SpriteComponent, TransformComponent, VisibilityComponent};
-use crate::features::egui::EguiRenderFeature;
 use crate::features::skybox::SkyboxRenderFeature;
 use crate::features::sprite::{SpriteRenderFeature, SpriteRenderObject, SpriteRenderObjectSet};
 use crate::features::text::{TextRenderFeature, TextResource};
@@ -265,12 +264,19 @@ fn update_main_view_2d(
         .add_render_phase::<UiRenderPhase>()
         .build();
 
-    let main_camera_feature_mask = RenderFeatureMaskBuilder::default()
-        .add_render_feature::<EguiRenderFeature>()
+    let mut main_camera_feature_mask = RenderFeatureMaskBuilder::default();
+    main_camera_feature_mask = main_camera_feature_mask
         .add_render_feature::<SkyboxRenderFeature>()
         .add_render_feature::<SpriteRenderFeature>()
-        .add_render_feature::<TextRenderFeature>()
-        .build();
+        .add_render_feature::<TextRenderFeature>();
+
+    #[cfg(feature = "egui")]
+    {
+        main_camera_feature_mask = main_camera_feature_mask
+            .add_render_feature::<crate::features::egui::EguiRenderFeature>();
+    }
+
+    let main_camera_feature_mask = main_camera_feature_mask.build();
 
     // Round to a whole number
 

--- a/demo/src/scenes/mod.rs
+++ b/demo/src/scenes/mod.rs
@@ -41,9 +41,9 @@ pub const ALL_SCENES: [Scene; 5] = [
 ];
 
 fn random_color(rng: &mut impl Rng) -> Vec3 {
-    let r = rng.gen_range(0.2, 1.0);
-    let g = rng.gen_range(0.2, 1.0);
-    let b = rng.gen_range(0.2, 1.0);
+    let r = rng.gen_range(0.2..1.0);
+    let g = rng.gen_range(0.2..1.0);
+    let b = rng.gen_range(0.2..1.0);
     let v = Vec3::new(r, g, b);
     v.normalize()
 }

--- a/demo/src/scenes/rafxmark_scene.rs
+++ b/demo/src/scenes/rafxmark_scene.rs
@@ -2,7 +2,6 @@
 
 use crate::assets::font::FontAsset;
 use crate::components::{SpriteComponent, TransformComponent, VisibilityComponent};
-use crate::features::egui::EguiRenderFeature;
 use crate::features::skybox::SkyboxRenderFeature;
 use crate::features::sprite::{SpriteRenderFeature, SpriteRenderObject, SpriteRenderObjectSet};
 use crate::features::text::{TextRenderFeature, TextResource};
@@ -341,12 +340,19 @@ fn update_main_view_2d(
         .add_render_phase::<UiRenderPhase>()
         .build();
 
-    let main_camera_feature_mask = RenderFeatureMaskBuilder::default()
-        .add_render_feature::<EguiRenderFeature>()
+    let mut main_camera_feature_mask = RenderFeatureMaskBuilder::default();
+    main_camera_feature_mask = main_camera_feature_mask
         .add_render_feature::<SkyboxRenderFeature>()
         .add_render_feature::<SpriteRenderFeature>()
-        .add_render_feature::<TextRenderFeature>()
-        .build();
+        .add_render_feature::<TextRenderFeature>();
+
+    #[cfg(feature = "egui")]
+    {
+        main_camera_feature_mask = main_camera_feature_mask
+            .add_render_feature::<crate::features::egui::EguiRenderFeature>();
+    }
+
+    let main_camera_feature_mask = main_camera_feature_mask.build();
 
     const CAMERA_Z: f32 = 1000.0;
 

--- a/demo/src/scenes/shadows_scene.rs
+++ b/demo/src/scenes/shadows_scene.rs
@@ -4,7 +4,6 @@ use crate::components::{
 };
 use crate::components::{SpotLightComponent, VisibilityComponent};
 use crate::features::debug3d::Debug3DRenderFeature;
-use crate::features::egui::EguiRenderFeature;
 use crate::features::mesh::{
     MeshNoShadowsRenderFeatureFlag, MeshRenderFeature, MeshRenderObject, MeshRenderObjectSet,
     MeshUnlitRenderFeatureFlag, MeshUntexturedRenderFeatureFlag, MeshWireframeRenderFeatureFlag,
@@ -150,7 +149,7 @@ impl ShadowsScene {
                 let mesh_render_object = example_meshes[i % example_meshes.len()].clone();
                 let asset_handle = &mesh_render_objects.get(&mesh_render_object).mesh;
 
-                let rand_scale = rng.gen_range(0.8, 1.2);
+                let rand_scale = rng.gen_range(0.8..1.2);
                 let offset = rand_scale - 1.;
                 let transform_component = TransformComponent {
                     translation: position + Vec3::new(0., 0., offset),
@@ -336,10 +335,14 @@ fn update_main_view_3d(
 
     let mut feature_mask_builder = RenderFeatureMaskBuilder::default()
         .add_render_feature::<MeshRenderFeature>()
-        .add_render_feature::<EguiRenderFeature>()
         .add_render_feature::<SpriteRenderFeature>()
         .add_render_feature::<TileLayerRenderFeature>();
 
+    #[cfg(feature = "egui")]
+    {
+        feature_mask_builder =
+            feature_mask_builder.add_render_feature::<crate::features::egui::EguiRenderFeature>();
+    }
     if render_options.show_text {
         feature_mask_builder = feature_mask_builder.add_render_feature::<TextRenderFeature>();
     }

--- a/demo/src/scenes/sprite_scene.rs
+++ b/demo/src/scenes/sprite_scene.rs
@@ -1,6 +1,5 @@
 use crate::assets::ldtk::LdtkProjectAsset;
 use crate::components::{SpriteComponent, TransformComponent, VisibilityComponent};
-use crate::features::egui::EguiRenderFeature;
 use crate::features::sprite::{SpriteRenderFeature, SpriteRenderObject, SpriteRenderObjectSet};
 use crate::features::text::TextRenderFeature;
 use crate::features::tile_layer::{
@@ -172,12 +171,19 @@ fn update_main_view_2d(
         .add_render_phase::<UiRenderPhase>()
         .build();
 
-    let main_camera_feature_mask = RenderFeatureMaskBuilder::default()
-        .add_render_feature::<EguiRenderFeature>()
+    let mut main_camera_feature_mask = RenderFeatureMaskBuilder::default();
+    main_camera_feature_mask = main_camera_feature_mask
         .add_render_feature::<SpriteRenderFeature>()
         .add_render_feature::<TextRenderFeature>()
-        .add_render_feature::<TileLayerRenderFeature>()
-        .build();
+        .add_render_feature::<TileLayerRenderFeature>();
+
+    #[cfg(feature = "egui")]
+    {
+        main_camera_feature_mask = main_camera_feature_mask
+            .add_render_feature::<crate::features::egui::EguiRenderFeature>();
+    }
+
+    let main_camera_feature_mask = main_camera_feature_mask.build();
 
     const CAMERA_XY_DISTANCE: f32 = 400.0;
     const CAMERA_Z: f32 = 1000.0;

--- a/deny.toml
+++ b/deny.toml
@@ -194,6 +194,5 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/gltf-rs/gltf.git",
     "https://github.com/amethyst/distill.git",
 ]

--- a/rafx-assets/Cargo.toml
+++ b/rafx-assets/Cargo.toml
@@ -23,12 +23,10 @@ rafx-api = { version = "=0.0.13", path = "../rafx-api" }
 rafx-base = { version = "=0.0.13", path = "../rafx-base" }
 rafx-framework = { version = "=0.0.13", path = "../rafx-framework" }
 distill = { version = "=0.0.3", features = ["serde_importers"] }
-basis-universal = "0.1.1"
+basis-universal = { version = "0.1.1", optional = true }
 type-uuid = "0.1"
 uuid = "0.8"
-#TODO: Not sure we really need both
 image = "0.23.12"
-image2 = { version = "0.11", features = ["ser"] }
 arrayvec = "0.5"
 crossbeam-channel = "0.5"
 fnv = "1.0"

--- a/rafx-assets/src/assets/image/assets.rs
+++ b/rafx-assets/src/assets/image/assets.rs
@@ -38,6 +38,7 @@ pub enum ImageAssetBasisCompressionType {
     Uastc,
 }
 
+#[cfg(feature = "basis-universal")]
 impl Into<basis_universal::BasisTextureFormat> for ImageAssetBasisCompressionType {
     fn into(self) -> basis_universal::BasisTextureFormat {
         match self {
@@ -53,6 +54,7 @@ pub struct ImageAssetBasisCompressionSettings {
     quality: u32,
 }
 
+#[cfg(feature = "basis-universal")]
 impl ImageAssetBasisCompressionSettings {
     pub fn default_uastc() -> Self {
         ImageAssetBasisCompressionSettings {
@@ -115,10 +117,18 @@ impl ImageAssetData {
     ) -> (ImageAssetDataFormatConfig, ImageAssetMipGeneration) {
         let compress_textures = false;
         if compress_textures {
-            let basis_settings = ImageAssetBasisCompressionSettings::default_uastc();
-            let format_config = ImageAssetDataFormatConfig::BasisCompressed(basis_settings);
-            let mipmap_generation = ImageAssetMipGeneration::Precomupted;
-            (format_config, mipmap_generation)
+            #[cfg(feature = "basis-universal")]
+            {
+                let basis_settings = ImageAssetBasisCompressionSettings::default_uastc();
+                let format_config = ImageAssetDataFormatConfig::BasisCompressed(basis_settings);
+                let mipmap_generation = ImageAssetMipGeneration::Precomupted;
+                (format_config, mipmap_generation)
+            }
+
+            #[cfg(not(feature = "basis-universal"))]
+            {
+                unimplemented!("Not built with basis-universal feature")
+            }
         } else {
             let format_config = ImageAssetDataFormatConfig::RawRGBA32;
             let mipmap_generation = ImageAssetMipGeneration::Runtime;
@@ -155,6 +165,11 @@ impl ImageAssetData {
                     data: raw_rgba32.to_vec(),
                 })
             }
+            #[cfg(not(feature = "basis-universal"))]
+            ImageAssetDataFormatConfig::BasisCompressed(settings) => {
+                unimplemented!("crate not built with basis-universal feature");
+            }
+            #[cfg(feature = "basis-universal")]
             ImageAssetDataFormatConfig::BasisCompressed(settings) => {
                 let generate_mips_at_runtime = match mip_generation {
                     ImageAssetMipGeneration::NoMips => false,

--- a/rafx-assets/src/assets/mod.rs
+++ b/rafx-assets/src/assets/mod.rs
@@ -1,4 +1,5 @@
 mod image;
+#[cfg(feature = "basis-universal")]
 pub use self::image::BasisImageImporter;
 pub use self::image::ImageAsset;
 pub use self::image::ImageAssetBasisCompressionSettings;

--- a/rafx-assets/src/assets/upload.rs
+++ b/rafx-assets/src/assets/upload.rs
@@ -8,6 +8,7 @@ use crate::{
     buffer_upload, image_upload, GpuImageData, GpuImageDataColorSpace, GpuImageDataLayer,
     GpuImageDataMipLevel,
 };
+#[cfg(feature = "basis-universal")]
 use basis_universal::{TranscodeParameters, TranscoderTextureFormat};
 use crossbeam_channel::{Receiver, Sender};
 use distill::loader::{storage::AssetLoadOp, LoadHandle};
@@ -667,6 +668,11 @@ impl UploadManager {
                 color_space.rgba8(),
                 request.asset.data,
             ),
+            #[cfg(not(feature = "basis-universal"))]
+            ImageAssetDataFormat::BasisCompressed => {
+                unimplemented!("Not built with basis-universal feature");
+            }
+            #[cfg(feature = "basis-universal")]
             ImageAssetDataFormat::BasisCompressed => {
                 let data = request.asset.data;
                 let mut transcoder = basis_universal::Transcoder::new();

--- a/rafx-assets/src/distill_impl/mod.rs
+++ b/rafx-assets/src/distill_impl/mod.rs
@@ -10,16 +10,22 @@ pub use asset_storage::*;
 pub fn default_daemon() -> distill::daemon::AssetDaemon {
     use crate::assets::*;
 
-    distill::daemon::AssetDaemon::default()
+    let mut daemon = distill::daemon::AssetDaemon::default()
         .with_importer("sampler", SamplerImporter)
         .with_importer("material", MaterialImporter)
         .with_importer("materialinstance", MaterialInstanceImporter)
         .with_importer("compute", ComputePipelineImporter)
         .with_importer("cookedshaderpackage", ShaderImporterCooked)
-        .with_importer("png", ImageImporter)
-        .with_importer("jpg", ImageImporter)
-        .with_importer("jpeg", ImageImporter)
-        .with_importer("tga", ImageImporter)
-        .with_importer("bmp", ImageImporter)
-        .with_importer("basis", BasisImageImporter)
+        .with_importer("png", ImageImporter(image::ImageFormat::Png))
+        .with_importer("jpg", ImageImporter(image::ImageFormat::Jpeg))
+        .with_importer("jpeg", ImageImporter(image::ImageFormat::Jpeg))
+        .with_importer("tga", ImageImporter(image::ImageFormat::Tga))
+        .with_importer("bmp", ImageImporter(image::ImageFormat::Bmp));
+
+    #[cfg(feature = "basis-universal")]
+    {
+        daemon = daemon.with_importer("basis", BasisImageImporter);
+    }
+
+    daemon
 }

--- a/rafx-framework/src/render_features/jobs/extract/extract_job.rs
+++ b/rafx-framework/src/render_features/jobs/extract/extract_job.rs
@@ -10,6 +10,7 @@ use std::ops::Range;
 pub struct ExtractJob<'extract, ExtractJobEntryPointsT: ExtractJobEntryPoints<'extract>> {
     inner: ExtractJobEntryPointsT,
     frame_packet: Option<Box<FramePacket<ExtractJobEntryPointsT::FramePacketDataT>>>,
+    #[allow(dead_code)]
     debug_constants: &'static RenderFeatureDebugConstants,
     _phantom: (PhantomData<&'extract ()>,),
 }

--- a/rafx-framework/src/render_features/jobs/prepare/prepare_job.rs
+++ b/rafx-framework/src/render_features/jobs/prepare/prepare_job.rs
@@ -10,6 +10,7 @@ pub struct PrepareJob<'prepare, PrepareJobEntryPointsT: PrepareJobEntryPoints<'p
     inner: PrepareJobEntryPointsT,
     frame_packet: Option<Box<FramePacket<PrepareJobEntryPointsT::FramePacketDataT>>>,
     submit_packet: Option<Box<SubmitPacket<PrepareJobEntryPointsT::SubmitPacketDataT>>>,
+    #[allow(dead_code)]
     debug_constants: &'static RenderFeatureDebugConstants,
     _phantom: (PhantomData<&'prepare ()>,),
 }

--- a/rafx-renderer/src/renderer.rs
+++ b/rafx-renderer/src/renderer.rs
@@ -488,8 +488,7 @@ impl Renderer {
     }
 
     pub fn calculate_frame_packet_size(
-        #[allow(unused_variables)]
-        debug_constants: &'static RenderFeatureDebugConstants,
+        #[allow(unused_variables)] debug_constants: &'static RenderFeatureDebugConstants,
         feature_index: RenderFeatureIndex,
         is_relevant: impl Fn(&RenderViewVisibilityQuery) -> bool,
         visibility_results: &Vec<RenderViewVisibilityQuery>,
@@ -604,8 +603,7 @@ impl Renderer {
     }
 
     pub fn populate_frame_packet(
-        #[allow(unused_variables)]
-        debug_constants: &'static RenderFeatureDebugConstants,
+        #[allow(unused_variables)] debug_constants: &'static RenderFeatureDebugConstants,
         feature_index: RenderFeatureIndex,
         is_relevant: impl Fn(&RenderViewVisibilityQuery) -> bool,
         visibility_results: &Vec<RenderViewVisibilityQuery>,

--- a/rafx-renderer/src/renderer.rs
+++ b/rafx-renderer/src/renderer.rs
@@ -488,6 +488,7 @@ impl Renderer {
     }
 
     pub fn calculate_frame_packet_size(
+        #[allow(unused_variables)]
         debug_constants: &'static RenderFeatureDebugConstants,
         feature_index: RenderFeatureIndex,
         is_relevant: impl Fn(&RenderViewVisibilityQuery) -> bool,
@@ -603,6 +604,7 @@ impl Renderer {
     }
 
     pub fn populate_frame_packet(
+        #[allow(unused_variables)]
         debug_constants: &'static RenderFeatureDebugConstants,
         feature_index: RenderFeatureIndex,
         is_relevant: impl Fn(&RenderViewVisibilityQuery) -> bool,

--- a/rafx/Cargo.toml
+++ b/rafx/Cargo.toml
@@ -54,6 +54,7 @@ static-vulkan = ["rafx-api/static-vulkan"]
 framework = ["rafx-framework"]
 assets = ["rafx-assets", "framework"]
 renderer = ["rafx-renderer", "assets"]
+basis-universal = ["rafx-assets/basis-universal"]
 
 #
 # Profiling features - passes down features to crates contained within this one


### PR DESCRIPTION
- Remove image2 dependency and use image everywhere instead
- Update to latest gltf
- Make basis-universal optional
- Make egui optional
- Update to more recent rand/pcg_rand version

These changes will be helpful for supporting building in wasm