### PR TITLE
Use Fully-Qualified Type Paths in Macros

### DIFF
--- a/docs/framework/adding_render_phases.md
+++ b/docs/framework/adding_render_phases.md
@@ -21,7 +21,7 @@ rafx::declare_render_phase!(
     shadow_map_render_phase_sort_submit_nodes
 );
 
-fn shadow_map_render_phase_sort_submit_nodes(submit_nodes: &mut Vec<SubmitNode>) {
+fn shadow_map_render_phase_sort_submit_nodes(submit_nodes: &mut Vec<RenderFeatureSubmitNode>) {
     // Sort by feature
     log::trace!(
         "Sort phase {}",

--- a/rafx-framework/src/render_features/macro_render_feature.rs
+++ b/rafx-framework/src/render_features/macro_render_feature.rs
@@ -19,7 +19,8 @@ macro_rules! declare_render_feature {
 
         pub struct $struct_name;
 
-        static RENDER_FEATURE_DEBUG_CONSTANTS: RenderFeatureDebugConstants = RenderFeatureDebugConstants {
+        static RENDER_FEATURE_DEBUG_CONSTANTS: $crate::render_features::RenderFeatureDebugConstants =
+                $crate::render_features::RenderFeatureDebugConstants {
             feature_name: stringify!($struct_name),
 
             begin_per_frame_extract: stringify!($struct_name begin_per_frame_extract),
@@ -40,11 +41,11 @@ macro_rules! declare_render_feature {
             revert_setup: stringify!($struct_name revert_setup),
         };
 
-        impl RenderFeature for $struct_name {
-            fn set_feature_index(index: RenderFeatureIndex) {
+        impl $crate::render_features::RenderFeature for $struct_name {
+            fn set_feature_index(index: $crate::render_features::RenderFeatureIndex) {
                 assert_eq!(
                     $struct_name::feature_index(),
-                    RenderFeatureIndex::MAX,
+                    $crate::render_features::RenderFeatureIndex::MAX,
                     "feature {} was already registered",
                     $struct_name::feature_debug_name(),
                 );
@@ -55,22 +56,22 @@ macro_rules! declare_render_feature {
                 );
             }
 
-            fn feature_index() -> RenderFeatureIndex {
+            fn feature_index() -> $crate::render_features::RenderFeatureIndex {
                 $atomic_constant_name.load(std::sync::atomic::Ordering::Acquire)
-                    as RenderFeatureIndex
+                    as $crate::render_features::RenderFeatureIndex
             }
 
             fn feature_debug_name() -> &'static str {
                 render_feature_debug_name()
             }
 
-            fn feature_debug_constants() -> &'static RenderFeatureDebugConstants {
+            fn feature_debug_constants() -> &'static $crate::render_features::RenderFeatureDebugConstants {
                 render_feature_debug_constants()
             }
         }
 
         #[inline(always)]
-        fn render_feature_index() -> RenderFeatureIndex {
+        fn render_feature_index() -> $crate::render_features::RenderFeatureIndex {
             $struct_name::feature_index()
         }
 
@@ -80,7 +81,7 @@ macro_rules! declare_render_feature {
         }
 
         #[inline(always)]
-        fn render_feature_debug_constants() -> &'static RenderFeatureDebugConstants {
+        fn render_feature_debug_constants() -> &'static $crate::render_features::RenderFeatureDebugConstants {
             &RENDER_FEATURE_DEBUG_CONSTANTS
         }
     };

--- a/rafx-framework/src/render_features/macro_render_feature_flag.rs
+++ b/rafx-framework/src/render_features/macro_render_feature_flag.rs
@@ -18,11 +18,11 @@ macro_rules! declare_render_feature_flag {
 
         pub struct $struct_name;
 
-        impl RenderFeatureFlag for $struct_name {
-            fn set_feature_flag_index(index: RenderFeatureFlagIndex) {
+        impl $crate::render_features::RenderFeatureFlag for $struct_name {
+            fn set_feature_flag_index(index: $crate::render_features::RenderFeatureFlagIndex) {
                 assert_eq!(
                     $struct_name::feature_flag_index(),
-                    RenderFeatureFlagIndex::MAX,
+                    $crate::render_features::RenderFeatureFlagIndex::MAX,
                     "feature flag {} was already registered",
                     $struct_name::feature_flag_debug_name(),
                 );
@@ -33,9 +33,9 @@ macro_rules! declare_render_feature_flag {
                 );
             }
 
-            fn feature_flag_index() -> RenderFeatureFlagIndex {
+            fn feature_flag_index() -> $crate::render_features::RenderFeatureFlagIndex {
                 $atomic_constant_name.load(std::sync::atomic::Ordering::Acquire)
-                    as RenderFeatureFlagIndex
+                    as $crate::render_features::RenderFeatureFlagIndex
             }
 
             fn feature_flag_debug_name() -> &'static str {

--- a/rafx-framework/src/render_features/macro_render_phase.rs
+++ b/rafx-framework/src/render_features/macro_render_phase.rs
@@ -27,11 +27,11 @@ macro_rules! declare_render_phase {
 
         pub struct $struct_name;
 
-        impl RenderPhase for $struct_name {
-            fn set_render_phase_index(index: RenderPhaseIndex) {
+        impl $crate::render_features::RenderPhase for $struct_name {
+            fn set_render_phase_index(index: $crate::render_features::RenderPhaseIndex) {
                 assert_eq!(
                     $struct_name::render_phase_index(),
-                    RenderPhaseIndex::MAX,
+                    $crate::render_features::RenderPhaseIndex::MAX,
                     "render phase {} was already registered",
                     $struct_name::render_phase_debug_name(),
                 );
@@ -43,11 +43,14 @@ macro_rules! declare_render_phase {
                 );
             }
 
-            fn render_phase_index() -> RenderPhaseIndex {
-                $atomic_constant_name.load(std::sync::atomic::Ordering::Acquire) as RenderPhaseIndex
+            fn render_phase_index() -> $crate::render_features::RenderPhaseIndex {
+                $atomic_constant_name.load(std::sync::atomic::Ordering::Acquire)
+                    as $crate::render_features::RenderPhaseIndex
             }
 
-            fn sort_submit_nodes(submit_nodes: &mut Vec<RenderFeatureSubmitNode>) {
+            fn sort_submit_nodes(
+                submit_nodes: &mut Vec<$crate::render_features::RenderFeatureSubmitNode>
+            ) {
                 $sort_fn(submit_nodes)
             }
 


### PR DESCRIPTION
I ran into an error because I didn't `use` the requried types before calling the macro. This makes sure that you don't have to `use` anything and the macro should work regardless.

Also updated an out-of-date code sample in one of the doc readmes.