### PR TITLE
Enable features on docs.rs

### DIFF
--- a/rafx/Cargo.toml
+++ b/rafx/Cargo.toml
@@ -79,3 +79,12 @@ required-features = ["framework"]
 name = "asset_triangle"
 path = "examples/asset_triangle/asset_triangle.rs"
 required-features = ["assets"]
+
+# Enable these features on docs.rs
+[package.metadata.docs.rs]
+features = [
+    "framework",
+    "assets",
+    "renderer",
+    "basis-universal",
+]

--- a/rafx/src/lib.rs
+++ b/rafx/src/lib.rs
@@ -1,7 +1,3 @@
-//! NOTE: **docs.rs may not generate complete documentation for rafx because it does not enable any
-//! features in cargo when building the docs.** To generate complete documentation locally, run
-//! `cargo doc --no-deps --open` in the root of the crate.
-//!
 //! **Please see [additional documentation here](https://github.com/aclysma/rafx/blob/master/docs/index.md)**
 //!
 //! Rafx is a multi-backend renderer that prioritizes performance, flexibility, and productivity. It


### PR DESCRIPTION
I think this should work, see [this](https://docs.rs/about/metadata). I wasn't sure about backends, so I left them out, but `all-features = true` might be nice.