### PR TITLE
Switch vk-mem (VMA) to gpu-allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,3 @@ split-debuginfo = "unpacked"
 #raw-gl-context = { git = "https://github.com/aclysma/raw-gl-context.git", branch = "rafx" }
 #basis-universal = { path = "../basis-universal-rs/basis-universal" }
 #basis-universal-sys = { path = "../basis-universal-rs/basis-universal-sys" }
-vk-mem = { git = "https://github.com/aclysma/vk-mem-rs.git", branch = "rafx-vk-mem" }

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -698,20 +698,6 @@ impl DemoApp {
                         return false;
                     }
 
-                    #[cfg(feature = "rafx-vulkan")]
-                    if *virtual_keycode == VirtualKeyCode::V {
-                        let stats = resources
-                            .get::<rafx::api::RafxDeviceContext>()
-                            .unwrap()
-                            .vk_device_context()
-                            .unwrap()
-                            .allocator()
-                            .calculate_stats()
-                            .unwrap();
-                        println!("{:#?}", stats);
-                        was_handled = true;
-                    }
-
                     if *virtual_keycode == VirtualKeyCode::Left {
                         scene_manager.queue_load_previous_scene();
                         was_handled = true;

--- a/deny.toml
+++ b/deny.toml
@@ -194,6 +194,5 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/amethyst/distill.git",
-    "https://github.com/aclysma/vk-mem-rs.git"
+    "https://github.com/amethyst/distill.git"
 ]

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -19,7 +19,7 @@ General:
 
 Vulkan:
  * `ash` and `ash-window`: https://github.com/MaikKlein/ash
- * `vk-mem`: https://github.com/gwihlidal/vk-mem-rs
+ * `gpu-allocator`: https://github.com/Traverse-Research/gpu-allocator
    
 Metal:
  * `metal`: https://github.com/gfx-rs/metal-rs

--- a/rafx-api/Cargo.toml
+++ b/rafx-api/Cargo.toml
@@ -31,8 +31,8 @@ raw-window-handle = "0.3"
 
 # vulkan
 ash = { version = "0.32", optional = true }
-vk-mem = { version = "0.2", optional = true }
 ash-window = { version = "0.6.0", optional = true }
+gpu-allocator = { version = "0.8.0", optional = true }
 
 # metal
 [target.'cfg(target_os="macos")'.dependencies]
@@ -66,7 +66,7 @@ web-sys = { version = "0.3.4", features = ["Document", "Element", "HtmlCanvasEle
 [features]
 default = []
 rafx-empty = []
-rafx-vulkan = ["ash", "vk-mem", "ash-window"]
+rafx-vulkan = ["ash", "gpu-allocator", "ash-window"]
 rafx-metal = ["metal_rs", "objc", "raw-window-metal", "cocoa-foundation", "dispatch", "foreign-types-shared", "block"]
 rafx-gles2 = ["winapi", "cocoa", "objc", "core-foundation", "x11"]
 rafx-gles3 = ["winapi", "cocoa", "objc", "core-foundation", "x11"]

--- a/rafx-api/src/backends/vulkan/internal/conversions.rs
+++ b/rafx-api/src/backends/vulkan/internal/conversions.rs
@@ -38,15 +38,14 @@ impl Into<vk::ColorComponentFlags> for RafxColorFlags {
     }
 }
 
-impl Into<vk_mem::MemoryUsage> for RafxMemoryUsage {
-    fn into(self) -> vk_mem::MemoryUsage {
-        use vk_mem::MemoryUsage;
+impl Into<gpu_allocator::MemoryLocation> for RafxMemoryUsage {
+    fn into(self) -> gpu_allocator::MemoryLocation {
+        use gpu_allocator::MemoryLocation;
         match self {
-            RafxMemoryUsage::Unknown => MemoryUsage::Unknown,
-            RafxMemoryUsage::GpuOnly => MemoryUsage::GpuOnly,
-            RafxMemoryUsage::CpuOnly => MemoryUsage::CpuOnly,
-            RafxMemoryUsage::CpuToGpu => MemoryUsage::CpuToGpu,
-            RafxMemoryUsage::GpuToCpu => MemoryUsage::GpuToCpu,
+            RafxMemoryUsage::Unknown => MemoryLocation::Unknown,
+            RafxMemoryUsage::GpuOnly => MemoryLocation::GpuOnly,
+            RafxMemoryUsage::CpuToGpu => MemoryLocation::CpuToGpu,
+            RafxMemoryUsage::GpuToCpu => MemoryLocation::GpuToCpu,
         }
     }
 }

--- a/rafx-api/src/backends/vulkan/internal/conversions.rs
+++ b/rafx-api/src/backends/vulkan/internal/conversions.rs
@@ -44,6 +44,7 @@ impl Into<gpu_allocator::MemoryLocation> for RafxMemoryUsage {
         match self {
             RafxMemoryUsage::Unknown => MemoryLocation::Unknown,
             RafxMemoryUsage::GpuOnly => MemoryLocation::GpuOnly,
+            RafxMemoryUsage::CpuOnly => MemoryLocation::CpuToGpu,
             RafxMemoryUsage::CpuToGpu => MemoryLocation::CpuToGpu,
             RafxMemoryUsage::GpuToCpu => MemoryLocation::GpuToCpu,
         }

--- a/rafx-api/src/error.rs
+++ b/rafx-api/src/error.rs
@@ -18,7 +18,7 @@ pub enum RafxError {
     #[cfg(feature = "rafx-vulkan")]
     VkCreateInstanceError(Arc<VkCreateInstanceError>),
     #[cfg(feature = "rafx-vulkan")]
-    VkMemError(Arc<vk_mem::Error>),
+    AllocationError(Arc<gpu_allocator::AllocationError>),
     #[cfg(any(feature = "rafx-gles2", feature = "rafx-gles3"))]
     GlError(u32),
 }
@@ -36,7 +36,7 @@ impl std::error::Error for RafxError {
             #[cfg(feature = "rafx-vulkan")]
             RafxError::VkCreateInstanceError(ref e) => Some(&**e),
             #[cfg(feature = "rafx-vulkan")]
-            RafxError::VkMemError(ref e) => Some(&**e),
+            RafxError::AllocationError(ref e) => Some(&**e),
             #[cfg(any(feature = "rafx-gles2", feature = "rafx-gles3"))]
             RafxError::GlError(_) => None,
         }
@@ -58,7 +58,7 @@ impl core::fmt::Display for RafxError {
             #[cfg(feature = "rafx-vulkan")]
             RafxError::VkCreateInstanceError(ref e) => e.fmt(fmt),
             #[cfg(feature = "rafx-vulkan")]
-            RafxError::VkMemError(ref e) => e.fmt(fmt),
+            RafxError::AllocationError(ref e) => e.fmt(fmt),
             #[cfg(any(feature = "rafx-gles2", feature = "rafx-gles3"))]
             RafxError::GlError(ref e) => e.fmt(fmt),
         }
@@ -105,8 +105,8 @@ impl From<VkCreateInstanceError> for RafxError {
 }
 
 #[cfg(feature = "rafx-vulkan")]
-impl From<vk_mem::Error> for RafxError {
-    fn from(error: vk_mem::Error) -> Self {
-        RafxError::VkMemError(Arc::new(error))
+impl From<gpu_allocator::AllocationError> for RafxError {
+    fn from(error: gpu_allocator::AllocationError) -> Self {
+        RafxError::AllocationError(Arc::new(error))
     }
 }

--- a/rafx-api/src/lib.rs
+++ b/rafx-api/src/lib.rs
@@ -220,7 +220,7 @@ pub use objc;
 #[cfg(feature = "rafx-vulkan")]
 pub use ash;
 #[cfg(feature = "rafx-vulkan")]
-pub use vk_mem;
+pub use gpu_allocator;
 
 //
 // Re-export upstream API-agnostic crates

--- a/rafx-api/src/types/misc.rs
+++ b/rafx-api/src/types/misc.rs
@@ -262,6 +262,9 @@ pub enum RafxMemoryUsage {
     /// The memory is only accessed by the GPU
     GpuOnly,
 
+    /// The memory is only accessed by the CPU
+    CpuOnly,
+
     /// The memory is written by the CPU and read by the GPU
     CpuToGpu,
 

--- a/rafx-api/src/types/misc.rs
+++ b/rafx-api/src/types/misc.rs
@@ -262,9 +262,6 @@ pub enum RafxMemoryUsage {
     /// The memory is only accessed by the GPU
     GpuOnly,
 
-    /// The memory is only accessed by the CPU
-    CpuOnly,
-
     /// The memory is written by the CPU and read by the GPU
     CpuToGpu,
 


### PR DESCRIPTION
vk-mem appears to no longer be maintained (https://github.com/gwihlidal/vk-mem-rs/issues/54), switching to gpu-allocator which is more active and used by embark.