### PR TITLE
Some api/framework level fixes

### DIFF
--- a/rafx-api/src/backends/metal/descriptor_set_array.rs
+++ b/rafx-api/src/backends/metal/descriptor_set_array.rs
@@ -168,9 +168,15 @@ impl RafxDescriptorSetArrayMetal {
 
         let argument_descriptors = &root_signature.inner.argument_descriptors[layout_index];
         //let immutable_samplers = &layout.immutable_samplers;
+
         let argument_buffer_data = if !argument_descriptors.is_empty()
         /*|| !immutable_samplers.is_empty()*/
         {
+            let argument_descriptors: Vec<_> = argument_descriptors
+                .iter()
+                .map(|x| x.clone().into())
+                .collect();
+
             let array = metal_rs::Array::from_owned_slice(&argument_descriptors);
             let encoder = device_context.device().new_argument_encoder(array);
 

--- a/rafx-api/src/types/definitions.rs
+++ b/rafx-api/src/types/definitions.rs
@@ -278,7 +278,7 @@ impl RafxShaderStageDef {
 }
 
 /// Indicates which immutable sampler is being set
-#[derive(Clone, Hash)]
+#[derive(Clone, Hash, Debug)]
 pub enum RafxImmutableSamplerKey<'a> {
     Name(&'a str),
     Binding(u32, u32),
@@ -298,6 +298,7 @@ impl<'a> RafxImmutableSamplerKey<'a> {
 }
 
 /// Describes an immutable sampler key/value pair
+#[derive(Debug)]
 pub struct RafxImmutableSamplers<'a> {
     pub key: RafxImmutableSamplerKey<'a>,
     pub samplers: &'a [RafxSampler],

--- a/rafx-api/src/types/misc.rs
+++ b/rafx-api/src/types/misc.rs
@@ -96,12 +96,17 @@ pub enum RafxColorType {
 bitflags::bitflags! {
     /// The current state of a resource. When an operation is performed that references a resource,
     /// it must be in the correct state. Resources are moved between state using barriers.
+    ///
+    /// The implementation of resource_state_to_access_flags() in the vulkan backend gives a more
+    /// thorough explanation for what these states imply about syncrhonization. See also
+    /// determine_pipeline_stage_flags() and resource_state_to_image_layout() in the vulkan backend.
     pub struct RafxResourceState: u32 {
         const UNDEFINED = 0;
         const VERTEX_AND_CONSTANT_BUFFER = 0x1;
         const INDEX_BUFFER = 0x2;
         /// Similar to vulkan's COLOR_ATTACHMENT_OPTIMAL image layout
         const RENDER_TARGET = 0x4;
+        /// Shader read/write
         const UNORDERED_ACCESS = 0x8;
         /// Similar to vulkan's DEPTH_STENCIL_ATTACHMENT_OPTIMAL image layout
         const DEPTH_WRITE = 0x10;

--- a/rafx-framework/src/resources/descriptor_sets/descriptor_set_pool_chunk.rs
+++ b/rafx-framework/src/resources/descriptor_sets/descriptor_set_pool_chunk.rs
@@ -144,7 +144,7 @@ fn copy_data_to_buffer<T: Copy>(
         .get_mut(&DescriptorSetBindingKey {
             dst_binding: element_key.dst_binding,
         })
-        .unwrap();
+        .expect("Tried to copy data into descriptor set internal buffer but could not find buffer for this binding. Is @[internal_buffer] missing in the shader?");
 
     if data.len() as u32 > buffer.buffer_info.per_descriptor_size {
         panic!(


### PR DESCRIPTION
 - Fix memory issue in metal backend that triggered validation and possibly UB
 - Support for immutable samplers in compute pipelines
 - Better error message when forgetting @[internal_buffer] and using it as if there is a backing internal buffer