### PR TITLE
Add support for debug naming and debug labels, automatically name nodes in the render graph

### DIFF
--- a/rafx-api/src/backends/gles2/device_context.rs
+++ b/rafx-api/src/backends/gles2/device_context.rs
@@ -79,6 +79,7 @@ impl RafxDeviceContextGles2Inner {
 
         let device_info = RafxDeviceInfo {
             supports_multithreaded_usage: false,
+            supports_debug_names: false,
             min_uniform_buffer_offset_alignment: pack_alignment,
             min_storage_buffer_offset_alignment: pack_alignment,
             upload_buffer_texture_alignment: pack_alignment,

--- a/rafx-api/src/backends/gles3/device_context.rs
+++ b/rafx-api/src/backends/gles3/device_context.rs
@@ -83,6 +83,7 @@ impl RafxDeviceContextGles3Inner {
 
         let device_info = RafxDeviceInfo {
             supports_multithreaded_usage: false,
+            supports_debug_names: false,
             min_uniform_buffer_offset_alignment,
             min_storage_buffer_offset_alignment: pack_alignment,
             upload_buffer_texture_alignment: pack_alignment,

--- a/rafx-api/src/backends/metal/device_context.rs
+++ b/rafx-api/src/backends/metal/device_context.rs
@@ -50,6 +50,7 @@ impl RafxDeviceContextMetalInner {
     pub fn new() -> RafxResult<Self> {
         let device_info = RafxDeviceInfo {
             supports_multithreaded_usage: true,
+            supports_debug_names: false,
             // pretty sure this is consistent across macOS device (maybe not M1, not sure)
             min_uniform_buffer_offset_alignment: 256,
             // based on one of the loosest vulkan limits (intel iGPU), can't find official value

--- a/rafx-api/src/backends/vulkan/buffer.rs
+++ b/rafx-api/src/backends/vulkan/buffer.rs
@@ -20,6 +20,10 @@ pub struct RafxBufferVulkan {
 }
 
 impl RafxBufferVulkan {
+    pub fn device_context(&self) -> &RafxDeviceContextVulkan {
+        &self.device_context
+    }
+
     pub fn vk_buffer(&self) -> vk::Buffer {
         self.buffer_raw.as_ref().unwrap().buffer
     }

--- a/rafx-api/src/backends/vulkan/command_buffer.rs
+++ b/rafx-api/src/backends/vulkan/command_buffer.rs
@@ -1019,4 +1019,19 @@ impl RafxCommandBufferVulkan {
 
         Ok(())
     }
+
+    pub fn cmd_begin_debug_label<T: AsRef<str>>(
+        &self,
+        name: T,
+    ) {
+        if let Some(reporter) = self.device_context.debug_reporter() {
+            reporter.cmd_begin_debug_label(self, name);
+        }
+    }
+
+    pub fn cmd_end_debug_label(&self) {
+        if let Some(reporter) = self.device_context.debug_reporter() {
+            reporter.cmd_end_debug_label(self);
+        }
+    }
 }

--- a/rafx-api/src/backends/vulkan/internal/conversions.rs
+++ b/rafx-api/src/backends/vulkan/internal/conversions.rs
@@ -1,11 +1,11 @@
 use crate::{
     RafxAddressMode, RafxBlendFactor, RafxBlendOp, RafxColorClearValue, RafxColorFlags,
-    RafxCompareOp, RafxCullMode, RafxDepthStencilClearValue, RafxFillMode, RafxFilterType,
-    RafxFrontFace, RafxIndexType, RafxLoadOp, RafxMemoryUsage, RafxMipMapMode,
+    RafxCompareOp, RafxCullMode, RafxDebugObject, RafxDepthStencilClearValue, RafxFillMode,
+    RafxFilterType, RafxFrontFace, RafxIndexType, RafxLoadOp, RafxMemoryUsage, RafxMipMapMode,
     RafxPrimitiveTopology, RafxSampleCount, RafxShaderStageFlags, RafxStencilOp, RafxStoreOp,
     RafxSwapchainColorSpace, RafxVertexAttributeRate,
 };
-use ash::vk;
+use ash::vk::{self, Handle};
 
 impl Into<vk::ColorSpaceKHR> for RafxSwapchainColorSpace {
     fn into(self) -> vk::ColorSpaceKHR {
@@ -283,6 +283,24 @@ impl Into<vk::ClearValue> for RafxDepthStencilClearValue {
                 depth: self.depth,
                 stencil: self.stencil,
             },
+        }
+    }
+}
+
+impl From<RafxDebugObject<'_>> for vk::ObjectType {
+    fn from(val: RafxDebugObject<'_>) -> Self {
+        match val {
+            RafxDebugObject::Buffer(_) => vk::ObjectType::BUFFER,
+            RafxDebugObject::Texture(_) => vk::ObjectType::IMAGE,
+        }
+    }
+}
+
+impl From<RafxDebugObject<'_>> for u64 {
+    fn from(val: RafxDebugObject<'_>) -> Self {
+        match val {
+            RafxDebugObject::Buffer(buffer) => buffer.vk_buffer().unwrap().vk_buffer().as_raw(),
+            RafxDebugObject::Texture(texture) => texture.vk_texture().unwrap().vk_image().as_raw(),
         }
     }
 }

--- a/rafx-api/src/backends/vulkan/internal/debug_reporter.rs
+++ b/rafx-api/src/backends/vulkan/internal/debug_reporter.rs
@@ -1,4 +1,4 @@
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
 
 use ash::extensions::ext::DebugUtils;
@@ -6,7 +6,10 @@ use ash::extensions::ext::DebugUtils;
 pub use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0};
 use ash::vk;
 
-const ERRORS_TO_IGNORE: [&'static str; 0] = [
+use crate::vulkan::{RafxCommandBufferVulkan, RafxDeviceContextVulkan};
+use crate::RafxDebugObject;
+
+const ERRORS_TO_IGNORE: [&str; 0] = [
     // Temporary - I suspect locally built validation on M1 mac has a bug
     //"VUID-VkWriteDescriptorSet-descriptorType-00332",
     //"VUID-VkWriteDescriptorSet-descriptorType-00333",
@@ -29,7 +32,7 @@ pub extern "system" fn vulkan_debug_callback(
     if !data.is_null() {
         let data_ptr = unsafe { &(*data) };
         if !data_ptr.p_message.is_null() {
-            let msg_ptr = (*data_ptr).p_message;
+            let msg_ptr = data_ptr.p_message;
             let msg = unsafe { CStr::from_ptr(msg_ptr) };
             if flags.intersects(vk::DebugUtilsMessageSeverityFlagsEXT::ERROR) {
                 let mut ignored = false;
@@ -65,6 +68,60 @@ pub extern "system" fn vulkan_debug_callback(
 pub struct VkDebugReporter {
     pub debug_report_loader: DebugUtils,
     pub debug_callback: vk::DebugUtilsMessengerEXT,
+}
+
+impl VkDebugReporter {
+    /// Sets a name for an object. This is useful when debugging with a graphics debugger such as renderdoc
+    /// or nsight graphics.
+    pub fn set_object_name(
+        &self,
+        device: &RafxDeviceContextVulkan,
+        object: RafxDebugObject,
+        name: impl AsRef<str>,
+    ) {
+        let cstring = CString::new(name.as_ref()).expect("Nul in object name");
+
+        let name_info = vk::DebugUtilsObjectNameInfoEXT::builder()
+            .object_type(object.into())
+            .object_handle(object.into())
+            .object_name(&cstring);
+
+        unsafe {
+            // failure to set the name is not fatal/considered an error since it otherwise has no impact on the program.
+            let _ = self
+                .debug_report_loader
+                .debug_utils_set_object_name(device.device().handle(), &name_info);
+        }
+    }
+
+    /// Begins a named debug region inside a command buffer.
+    pub fn cmd_begin_debug_label<T: AsRef<str>>(
+        &self,
+        command_buffer: &RafxCommandBufferVulkan,
+        name: T,
+    ) {
+        let cstring = CString::new(name.as_ref()).expect("Nul in command buffer label");
+
+        let label_info = vk::DebugUtilsLabelEXT::builder().label_name(&cstring);
+
+        unsafe {
+            let _ = self
+                .debug_report_loader
+                .cmd_begin_debug_utils_label(command_buffer.vk_command_buffer(), &label_info);
+        }
+    }
+
+    /// Ends a previous named debug region inside a command buffer.
+    pub fn cmd_end_debug_label(
+        &self,
+        command_buffer: &RafxCommandBufferVulkan,
+    ) {
+        unsafe {
+            let _ = self
+                .debug_report_loader
+                .cmd_end_debug_utils_label(command_buffer.vk_command_buffer());
+        }
+    }
 }
 
 impl Drop for VkDebugReporter {

--- a/rafx-api/src/backends/vulkan/internal/instance.rs
+++ b/rafx-api/src/backends/vulkan/internal/instance.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 pub struct VkInstance {
     pub entry: Arc<VkEntry>,
     pub instance: ash::Instance,
-    pub debug_reporter: Option<VkDebugReporter>,
+    pub debug_reporter: Option<Arc<VkDebugReporter>>,
 }
 
 #[derive(Debug)]
@@ -209,7 +209,7 @@ impl VkInstance {
         Ok(VkInstance {
             entry: Arc::new(entry),
             instance,
-            debug_reporter,
+            debug_reporter: debug_reporter.map(Arc::new),
         })
     }
 

--- a/rafx-api/src/buffer.rs
+++ b/rafx-api/src/buffer.rs
@@ -16,7 +16,7 @@ use crate::gles3::RafxBufferGles3;
 use crate::metal::RafxBufferMetal;
 #[cfg(feature = "rafx-vulkan")]
 use crate::vulkan::RafxBufferVulkan;
-use crate::{RafxBufferDef, RafxResult};
+use crate::{RafxBufferDef, RafxDebugObject, RafxResult};
 
 /// Memory that can be accessed by the rendering API. It may reside in CPU or GPU memory.
 ///
@@ -216,6 +216,21 @@ impl RafxBuffer {
                 ))
             ))]
             RafxBuffer::Empty(inner) => inner.mapped_memory(),
+        }
+    }
+
+    /// Sets a name for this buffer. This is useful for debugging, graphics debuggers/profilers such
+    /// as nsight graphics or renderdoc will display this buffer with the given name in the list of resources.
+    pub fn set_name(
+        &self,
+        name: impl AsRef<str>,
+    ) {
+        match self {
+            #[cfg(feature = "rafx-vulkan")]
+            RafxBuffer::Vk(inner) => inner
+                .device_context()
+                .set_object_name(RafxDebugObject::Buffer(self), name),
+            _ => {}
         }
     }
 

--- a/rafx-api/src/command_buffer.rs
+++ b/rafx-api/src/command_buffer.rs
@@ -1080,6 +1080,28 @@ impl RafxCommandBuffer {
         }
     }
 
+    /// Begins labeling the following commands with the given name until [`cmd_end_debug_label`] is called.
+    /// This is useful for grouping together commands for use in a debugger.
+    pub fn cmd_begin_debug_label<T: AsRef<str>>(
+        &self,
+        name: T,
+    ) {
+        match self {
+            #[cfg(feature = "rafx-vulkan")]
+            RafxCommandBuffer::Vk(inner) => inner.cmd_begin_debug_label(name),
+            _ => {}
+        }
+    }
+
+    /// Ends a debug label that was started with [`cmd_begin_debug_label`].
+    pub fn cmd_end_debug_label(&self) {
+        match self {
+            #[cfg(feature = "rafx-vulkan")]
+            RafxCommandBuffer::Vk(inner) => inner.cmd_end_debug_label(),
+            _ => {}
+        }
+    }
+
     /// Get the underlying vulkan API object. This provides access to any internally created
     /// vulkan objects.
     #[cfg(feature = "rafx-vulkan")]

--- a/rafx-api/src/device_context.rs
+++ b/rafx-api/src/device_context.rs
@@ -632,6 +632,25 @@ impl RafxDeviceContext {
         })
     }
 
+    /// Sets a name for an object. This is useful when debugging with a graphics debugger such as renderdoc
+    /// or nsight graphics.
+    ///
+    /// # Note
+    ///
+    /// Failure to set a name is not considered to be an error since it does not affect the functionality of the program.
+    /// Moreover, on platforms where this function is unsupported (whether because of rafx or the API), this function is a no-op.
+    pub fn set_object_name<'a, T: Into<RafxDebugObject<'a>>>(
+        &self,
+        object: T,
+        name: impl AsRef<str>,
+    ) {
+        match self {
+            #[cfg(feature = "rafx-vulkan")]
+            RafxDeviceContext::Vk(inner) => inner.set_object_name(object.into(), name),
+            _ => {}
+        }
+    }
+
     /// Get the underlying vulkan API object. This provides access to any internally created
     /// vulkan objects.
     #[cfg(feature = "rafx-vulkan")]

--- a/rafx-api/src/texture.rs
+++ b/rafx-api/src/texture.rs
@@ -16,7 +16,7 @@ use crate::gles3::RafxTextureGles3;
 use crate::metal::RafxTextureMetal;
 #[cfg(feature = "rafx-vulkan")]
 use crate::vulkan::RafxTextureVulkan;
-use crate::RafxTextureDef;
+use crate::{RafxDebugObject, RafxTextureDef};
 
 /// An image that can be used by the GPU.
 ///
@@ -65,6 +65,21 @@ impl RafxTexture {
                 ))
             ))]
             RafxTexture::Empty(inner) => inner.texture_def(),
+        }
+    }
+
+    /// Sets a name for this texture. This is useful for debugging, graphics debuggers/profilers such
+    /// as nsight graphics or renderdoc will display this texture with the given name in the list of resources.
+    pub fn set_name(
+        &self,
+        name: impl AsRef<str>,
+    ) {
+        match self {
+            #[cfg(feature = "rafx-vulkan")]
+            RafxTexture::Vk(inner) => inner
+                .device_context()
+                .set_object_name(RafxDebugObject::Texture(self), name),
+            _ => {}
         }
     }
 

--- a/rafx-api/src/types/misc.rs
+++ b/rafx-api/src/types/misc.rs
@@ -37,6 +37,9 @@ impl Default for RafxValidationMode {
 /// indicate whether certain features are supported
 pub struct RafxDeviceInfo {
     pub supports_multithreaded_usage: bool,
+    /// Whether this device supports naming objects (i.e. `set_object_name` is not a no-op). This is
+    /// false on any backends which do not support naming, and true on vulkan if debug utils are active.
+    pub supports_debug_names: bool,
 
     pub min_uniform_buffer_offset_alignment: u32,
     pub min_storage_buffer_offset_alignment: u32,
@@ -956,4 +959,24 @@ pub struct RafxDispatchIndirectCommand {
     pub group_count_x: u32,
     pub group_count_y: u32,
     pub group_count_z: u32,
+}
+
+/// A reference to a type which can be labeled for debugging purposes
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub enum RafxDebugObject<'a> {
+    Buffer(&'a RafxBuffer),
+    Texture(&'a RafxTexture),
+}
+
+impl<'a> From<&'a RafxBuffer> for RafxDebugObject<'a> {
+    fn from(buffer: &'a RafxBuffer) -> Self {
+        RafxDebugObject::Buffer(buffer)
+    }
+}
+
+impl<'a> From<&'a RafxTexture> for RafxDebugObject<'a> {
+    fn from(texture: &'a RafxTexture) -> Self {
+        RafxDebugObject::Texture(texture)
+    }
 }

--- a/rafx-framework/src/graph/graph_image.rs
+++ b/rafx-framework/src/graph/graph_image.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::*;
 use rafx_api::{RafxExtents3D, RafxFormat, RafxResourceType, RafxSampleCount, RafxTextureBindType};
 

--- a/rafx-framework/src/graph/graph_plan.rs
+++ b/rafx-framework/src/graph/graph_plan.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::*;
 use super::{RenderGraphExternalImageId, RenderGraphImageSpecification};
 use crate::graph::graph_image::{PhysicalImageId, RenderGraphImageUser, VirtualImageId};
@@ -7,7 +9,9 @@ use crate::render_features::RenderPhaseIndex;
 use crate::{BufferResource, GraphicsPipelineRenderTargetMeta};
 use crate::{ImageViewResource, ResourceArc};
 use fnv::{FnvHashMap, FnvHashSet};
-use rafx_api::{RafxFormat, RafxLoadOp, RafxResourceState, RafxSampleCount, RafxStoreOp};
+use rafx_api::{
+    RafxDebugObject, RafxFormat, RafxLoadOp, RafxResourceState, RafxSampleCount, RafxStoreOp,
+};
 
 // Recursively called to topologically sort the nodes to determine execution order. See
 // determine_node_order which kicks this off.

--- a/rafx-framework/src/graph/prepared_graph.rs
+++ b/rafx-framework/src/graph/prepared_graph.rs
@@ -340,6 +340,10 @@ impl PreparedRenderGraph {
             profiling::scope!("pass", pass.debug_name().unwrap_or("unnamed"));
             log::trace!("Execute pass name: {:?}", pass.debug_name());
 
+            if let Some(name) = pass.debug_name() {
+                command_buffer.cmd_begin_debug_label(name);
+            }
+
             let node_id = pass.node();
 
             if let Some(pre_pass_barrier) = pass.pre_pass_barrier() {
@@ -446,6 +450,10 @@ impl PreparedRenderGraph {
                     &post_pass_barrier.buffer_barriers,
                     &post_pass_barrier.image_barriers,
                 )?;
+            }
+
+            if pass.debug_name().is_some() {
+                command_buffer.cmd_end_debug_label();
             }
         }
 


### PR DESCRIPTION
This PR adds APIs for naming resources (currently just buffers and textures) and command buffer labels in rafx-api. The rendergraph uses the APIs to label nodes if they have a name, which significantly improves the debugging experience: 

![unknown (16)](https://user-images.githubusercontent.com/38166539/189505659-93f0a16b-8fa8-45c9-8b66-2956d928f369.png)

It currently only supports vulkan, other backends have the functions but they are no-ops. But adding support for other platforms should be really easy, i just have no way to test it for backends like metal.