### PR TITLE
Fix render graph when no renderpass callback is set

### DIFF
--- a/docs/api/safety.md
+++ b/docs/api/safety.md
@@ -96,7 +96,7 @@ The Render Graph Triangle example shows a simple render graph with one step.
 
 ```rust
 // Create a renderpass with a single color attachment
-let node = graph_builder.add_node("opaque", RenderGraphQueue::DefaultGraphics);
+let node = graph_builder.add_renderpass_node("opaque", RenderGraphQueue::DefaultGraphics);
 let color_attachment = graph_builder.create_color_attachment(
    node,
    0,

--- a/docs/framework/render_graph.md
+++ b/docs/framework/render_graph.md
@@ -32,7 +32,7 @@ let mut graph_builder = RenderGraphBuilder::default();
 let mut graph_callbacks = RenderGraphNodeCallbacks::<()>::default();
 
 // The string name is for logging/debugging purposes only
-let node = graph_builder.add_node("opaque", RenderGraphQueue::DefaultGraphics);
+let node = graph_builder.add_renderpass_node("opaque", RenderGraphQueue::DefaultGraphics);
 ```
 
 ## Adding Render Pass Attachments

--- a/rafx-framework/src/graph/graph_node.rs
+++ b/rafx-framework/src/graph/graph_node.rs
@@ -11,6 +11,12 @@ pub struct RenderGraphNodeId(pub(super) usize);
 
 pub type RenderGraphNodeName = &'static str;
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum RenderGraphNodeKind {
+    Renderpass,
+    Callback,
+}
+
 #[derive(Debug, Clone)]
 pub struct RenderGraphImageCreate {
     pub image: RenderGraphImageUsageId,
@@ -135,6 +141,7 @@ impl std::fmt::Debug for RenderGraphPassResolveAttachmentInfo {
 pub struct RenderGraphNode {
     id: RenderGraphNodeId,
     pub(super) name: Option<RenderGraphNodeName>,
+    pub(super) kind: RenderGraphNodeKind,
     #[allow(dead_code)]
     pub(super) queue: RenderGraphQueue,
     pub(super) can_be_culled: bool,
@@ -222,11 +229,13 @@ impl RenderGraphNode {
     pub(super) fn new(
         id: RenderGraphNodeId,
         name: Option<RenderGraphNodeName>,
+        kind: RenderGraphNodeKind,
         queue: RenderGraphQueue,
     ) -> Self {
         RenderGraphNode {
             id,
             name,
+            kind,
             queue,
             can_be_culled: true,
             image_creates: Default::default(),

--- a/rafx-framework/src/graph/graph_pass.rs
+++ b/rafx-framework/src/graph/graph_pass.rs
@@ -155,7 +155,6 @@ pub struct RenderGraphRenderPass {
 
     // For when we want to do layout transitions on non-attachments
     pub(super) pre_pass_barrier: Option<PrepassBarrier>,
-    pub(super) post_pass_barrier: Option<PostpassBarrier>,
 }
 
 #[derive(Debug)]
@@ -218,7 +217,6 @@ pub struct RenderGraphDepthStencilRenderTarget {
 pub struct RenderGraphOutputRenderPass {
     pub(super) node_id: RenderGraphNodeId,
     pub(super) pre_pass_barrier: Option<PrepassBarrier>,
-    pub(super) post_pass_barrier: Option<PostpassBarrier>,
     pub(super) debug_name: Option<RenderGraphNodeName>,
     pub(super) attachment_images: Vec<PhysicalImageViewId>,
     pub(super) color_render_targets: Vec<RenderGraphColorRenderTarget>,
@@ -243,7 +241,6 @@ impl std::fmt::Debug for RenderGraphOutputRenderPass {
 pub struct RenderGraphOutputCallbackPass {
     pub(super) node: RenderGraphNodeId,
     pub(super) pre_pass_barrier: Option<PrepassBarrier>,
-    pub(super) post_pass_barrier: Option<PostpassBarrier>,
     pub(super) debug_name: Option<RenderGraphNodeName>,
 }
 
@@ -265,13 +262,6 @@ impl RenderGraphOutputPass {
         match self {
             RenderGraphOutputPass::Render(pass) => pass.pre_pass_barrier.as_ref(),
             RenderGraphOutputPass::Callback(pass) => pass.pre_pass_barrier.as_ref(),
-        }
-    }
-
-    pub fn post_pass_barrier(&self) -> Option<&PostpassBarrier> {
-        match self {
-            RenderGraphOutputPass::Render(pass) => pass.post_pass_barrier.as_ref(),
-            RenderGraphOutputPass::Callback(pass) => pass.post_pass_barrier.as_ref(),
         }
     }
 

--- a/rafx-framework/src/graph/graph_plan.rs
+++ b/rafx-framework/src/graph/graph_plan.rs
@@ -1625,7 +1625,6 @@ fn build_physical_passes(
                     depth_attachment: pass_depth_attachment,
                     resolve_attachments: pass_resolve_attachments,
                     pre_pass_barrier: None,
-                    post_pass_barrier: None,
                 }));
             }
         }
@@ -2843,7 +2842,6 @@ fn create_output_passes(
                     node_id: pass.node_id,
                     attachment_images,
                     pre_pass_barrier: pass.pre_pass_barrier,
-                    post_pass_barrier: pass.post_pass_barrier,
                     debug_name,
                     color_render_targets,
                     depth_stencil_render_target,
@@ -2856,7 +2854,6 @@ fn create_output_passes(
                 let output_pass = RenderGraphOutputCallbackPass {
                     node: pass.node,
                     pre_pass_barrier: pass.pre_pass_barrier,
-                    post_pass_barrier: None,
                     debug_name,
                 };
 

--- a/rafx-framework/src/graph/graph_plan.rs
+++ b/rafx-framework/src/graph/graph_plan.rs
@@ -1374,7 +1374,7 @@ fn build_physical_passes(
 ) -> Vec<RenderGraphPass> {
     #[derive(Debug)]
     enum PassNode {
-        RenderNode(RenderGraphNodeId),
+        RenderpassNode(RenderGraphNodeId),
         CallbackNode(RenderGraphNodeId),
     }
 
@@ -1382,10 +1382,9 @@ fn build_physical_passes(
     let mut pass_nodes = Vec::default();
 
     for node_id in node_execution_order {
-        let pass_node = match graph.visit_node_callbacks.get(node_id) {
-            Some(RenderGraphNodeVisitNodeCallback::Render(_)) => PassNode::RenderNode(*node_id),
-            // If no callback is registered just take the callback path but don't do a callback
-            _ => PassNode::CallbackNode(*node_id),
+        let pass_node = match graph.node(*node_id).kind {
+            RenderGraphNodeKind::Renderpass => PassNode::RenderpassNode(*node_id),
+            RenderGraphNodeKind::Callback => PassNode::CallbackNode(*node_id),
         };
         pass_nodes.push(pass_node);
     }
@@ -1437,7 +1436,7 @@ fn build_physical_passes(
                     pre_pass_barrier: Default::default(),
                 }));
             }
-            PassNode::RenderNode(renderpass_node) => {
+            PassNode::RenderpassNode(renderpass_node) => {
                 let mut renderpass_attachments = Vec::default();
 
                 log::trace!("    subpass node: {:?}", renderpass_node);
@@ -2252,11 +2251,18 @@ fn build_node_barriers(
     node_execution_order: &[RenderGraphNodeId],
     _constraints: &DetermineConstraintsResult,
     physical_resources: &AssignPhysicalResourcesResult,
+    builtin_final_node: RenderGraphNodeId,
 ) -> FnvHashMap<RenderGraphNodeId, RenderGraphNodeResourceBarriers> {
     let mut resource_barriers =
         FnvHashMap::<RenderGraphNodeId, RenderGraphNodeResourceBarriers>::default();
 
     for node_id in node_execution_order {
+        // A special final node is added to every graph to handle transitioning any output
+        // images/buffers to their final state, so break out here and handle logic for this below
+        if *node_id == builtin_final_node {
+            break;
+        }
+
         let node = graph.node(*node_id);
         let mut image_node_barriers: FnvHashMap<PhysicalImageId, RenderGraphPassImageBarriers> =
             Default::default();
@@ -2456,6 +2462,47 @@ fn build_node_barriers(
             },
         );
     }
+
+    // A special final node is added to every graph to handle transitioning any output
+    // images/buffers to their final state. We handle setting up the required barriers for that
+    // node here.
+    let _builtin_final_node = graph.node(builtin_final_node);
+    let mut final_image_node_barriers: FnvHashMap<PhysicalImageId, RenderGraphPassImageBarriers> =
+        Default::default();
+    let mut final_buffer_node_barriers: FnvHashMap<
+        PhysicalBufferId,
+        RenderGraphPassBufferBarriers,
+    > = Default::default();
+
+    for external_image in &graph.external_images {
+        if let Some(output_usage) = external_image.output_usage {
+            add_image_barrier_for_node(
+                physical_resources,
+                &mut final_image_node_barriers,
+                output_usage,
+                external_image.final_state,
+            );
+        }
+    }
+
+    for external_buffer in &graph.external_buffers {
+        if let Some(output_usage) = external_buffer.output_usage {
+            add_buffer_barrier_for_node(
+                physical_resources,
+                &mut final_buffer_node_barriers,
+                output_usage,
+                external_buffer.final_state,
+            );
+        }
+    }
+
+    resource_barriers.insert(
+        builtin_final_node,
+        RenderGraphNodeResourceBarriers {
+            image_barriers: final_image_node_barriers,
+            buffer_barriers: final_buffer_node_barriers,
+        },
+    );
 
     resource_barriers
 }
@@ -2668,56 +2715,6 @@ fn build_pass_barriers(
 
             pass.set_pre_pass_barrier(barrier);
         }
-
-        // TODO: Figure out how to handle output images
-        // TODO: This only works if no one else reads it?
-        // TODO: Do we need to do something like this for buffers?
-        log::trace!("Check for output images");
-        for external_image in &graph.external_images {
-            if let Some(output_usage) = external_image.output_usage {
-                if graph.image_version_info(output_usage).creator_node == subpass_node_id {
-                    let output_physical_image =
-                        physical_resources.image_usage_to_physical[&output_usage];
-                    log::trace!(
-                        "External image {:?} usage {:?} created by node {:?} physical image {:?}",
-                        external_image.external_image_id,
-                        output_usage,
-                        subpass_node_id,
-                        output_physical_image
-                    );
-
-                    if let RenderGraphPass::Render(pass) = pass {
-                        let mut image_barriers = vec![];
-
-                        for (attachment_index, attachment) in
-                            &mut pass.attachments.iter_mut().enumerate()
-                        {
-                            if attachment.image.unwrap() == output_physical_image {
-                                log::trace!("  attachment {}", attachment_index);
-
-                                if attachment.final_state != external_image.final_state {
-                                    image_barriers.push(PrepassImageBarrier {
-                                        image: attachment.image.unwrap(),
-                                        old_state: attachment.final_state.into(),
-                                        new_state: external_image.final_state.into(),
-                                    })
-                                }
-                            }
-                        }
-
-                        if !image_barriers.is_empty() {
-                            pass.post_pass_barrier = Some(PostpassBarrier {
-                                buffer_barriers: vec![],
-                                image_barriers,
-                            });
-                        }
-                    }
-                    //TODO: Need a 0 -> EXTERNAL dependency here?
-                }
-            }
-        }
-
-        //TODO: Need to do a dependency? Maybe by adding a flush?
     }
 }
 
@@ -3386,6 +3383,14 @@ impl RenderGraphPlan {
         log::trace!("-- Create render graph plan --");
 
         //
+        // We add an extra node that always runs at the end. This lets us use the same codepath for
+        // inserting barriers before nodes in the graph to insert barriers at the end of the graph
+        // for "output" images/buffers
+        //
+        let builtin_final_node =
+            graph.add_callback_node("BuiltinFinalNode", RenderGraphQueue::DefaultGraphics);
+
+        //
         // Walk backwards through the DAG, starting from the output images, through all the upstream
         // dependencies of those images. We are doing a depth first search. Nodes that make no
         // direct or indirect contribution to an output image will not be included. As an
@@ -3394,7 +3399,8 @@ impl RenderGraphPlan {
         //
 
         //TODO: Support to force a node to be executed/unculled
-        let node_execution_order = determine_node_order(&graph);
+        let mut node_execution_order = determine_node_order(&graph);
+        node_execution_order.push(builtin_final_node);
 
         // Print out the execution order
         log::trace!("Execution order of unculled nodes:");
@@ -3464,6 +3470,7 @@ impl RenderGraphPlan {
             &node_execution_order,
             &constraint_results,
             &assign_physical_resources_result, /*, &determine_image_layouts_result*/
+            builtin_final_node,
         );
 
         print_node_barriers(&node_barriers);

--- a/rafx-framework/src/graph/mod.rs
+++ b/rafx-framework/src/graph/mod.rs
@@ -44,11 +44,11 @@ use rafx_api::RafxResult;
 pub type RenderGraphResourceName = &'static str;
 
 enum RenderGraphNodeVisitNodeCallback {
-    Render(Box<RenderGraphNodeVisitRenderNodeCallback>),
+    Render(Box<RenderGraphNodeVisitRenderpassNodeCallback>),
     Callback(Box<RenderGraphNodeVisitCallbackNodeCallback>),
 }
 
-type RenderGraphNodeVisitRenderNodeCallback =
+type RenderGraphNodeVisitRenderpassNodeCallback =
     dyn Fn(VisitRenderpassNodeArgs) -> RafxResult<()> + Send;
 
 type RenderGraphNodeVisitCallbackNodeCallback =

--- a/rafx-framework/src/graph/prepared_graph.rs
+++ b/rafx-framework/src/graph/prepared_graph.rs
@@ -434,19 +434,6 @@ impl PreparedRenderGraph {
                     self.visit_callback_node(node_id, args)?;
                 }
             }
-
-            if let Some(post_pass_barrier) = pass.post_pass_barrier() {
-                log::trace!(
-                    "postpass barriers for pass {} {:?}",
-                    pass_index,
-                    pass.debug_name()
-                );
-                self.insert_barriers(
-                    &command_buffer,
-                    &post_pass_barrier.buffer_barriers,
-                    &post_pass_barrier.image_barriers,
-                )?;
-            }
         }
 
         command_buffer.end()?;

--- a/rafx-plugins/src/pipelines/basic/graph_generator/bloom_blur_pass.rs
+++ b/rafx-plugins/src/pipelines/basic/graph_generator/bloom_blur_pass.rs
@@ -51,7 +51,7 @@ fn bloom_blur_internal_pass(
 ) -> RenderGraphImageUsageId {
     let node = context
         .graph
-        .add_node("BloomBlur", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("BloomBlur", RenderGraphQueue::DefaultGraphics);
     let blur_dst = context.graph.create_color_attachment(
         node,
         0,

--- a/rafx-plugins/src/pipelines/basic/graph_generator/bloom_combine_pass.rs
+++ b/rafx-plugins/src/pipelines/basic/graph_generator/bloom_combine_pass.rs
@@ -31,7 +31,7 @@ pub(super) fn bloom_combine_pass(
         .clone();
     let node = context
         .graph
-        .add_node("BloomCombine", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("BloomCombine", RenderGraphQueue::DefaultGraphics);
 
     let color = context.graph.create_color_attachment(
         node,

--- a/rafx-plugins/src/pipelines/basic/graph_generator/bloom_extract_pass.rs
+++ b/rafx-plugins/src/pipelines/basic/graph_generator/bloom_extract_pass.rs
@@ -23,7 +23,7 @@ pub(super) fn bloom_extract_pass(
 ) -> BloomExtractPass {
     let node = context
         .graph
-        .add_node("BloomExtract", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("BloomExtract", RenderGraphQueue::DefaultGraphics);
 
     let sdr_image = context.graph.create_color_attachment(
         node,

--- a/rafx-plugins/src/pipelines/basic/graph_generator/debug_pip_pass.rs
+++ b/rafx-plugins/src/pipelines/basic/graph_generator/debug_pip_pass.rs
@@ -17,7 +17,7 @@ pub(super) fn debug_pip_pass(
     // This node has a single color attachment
     let node = context
         .graph
-        .add_node("DebugPip", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("DebugPip", RenderGraphQueue::DefaultGraphics);
     let color = context.graph.modify_color_attachment(
         node,
         previous_pass_color,

--- a/rafx-plugins/src/pipelines/basic/graph_generator/depth_prepass.rs
+++ b/rafx-plugins/src/pipelines/basic/graph_generator/depth_prepass.rs
@@ -20,7 +20,7 @@ pub(super) fn depth_prepass(context: &mut BasicPipelineContext) -> Option<DepthP
 
     let node = context
         .graph
-        .add_node("DepthPrepass", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("DepthPrepass", RenderGraphQueue::DefaultGraphics);
 
     let depth = context.graph.create_depth_attachment(
         node,

--- a/rafx-plugins/src/pipelines/basic/graph_generator/opaque_pass.rs
+++ b/rafx-plugins/src/pipelines/basic/graph_generator/opaque_pass.rs
@@ -22,7 +22,7 @@ pub(super) fn opaque_pass(
 ) -> OpaquePass {
     let node = context
         .graph
-        .add_node("Opaque", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("Opaque", RenderGraphQueue::DefaultGraphics);
 
     let color = context.graph.create_color_attachment(
         node,

--- a/rafx-plugins/src/pipelines/basic/graph_generator/shadow_map_pass.rs
+++ b/rafx-plugins/src/pipelines/basic/graph_generator/shadow_map_pass.rs
@@ -31,7 +31,7 @@ pub(super) fn shadow_map_passes(
             MeshBasicShadowMapRenderView::Single(render_view) => {
                 let shadow_map_node = context
                     .graph
-                    .add_node("create shadowmap", RenderGraphQueue::DefaultGraphics);
+                    .add_renderpass_node("create shadowmap", RenderGraphQueue::DefaultGraphics);
                 let depth_image = context.graph.create_unattached_image(
                     shadow_map_node,
                     RenderGraphImageConstraint {
@@ -50,9 +50,10 @@ pub(super) fn shadow_map_passes(
                 shadow_map_passes.push(ShadowMapImageResources::Single(shadow_map_pass.depth));
             }
             MeshBasicShadowMapRenderView::Cube(render_view) => {
-                let cube_map_node = context
-                    .graph
-                    .add_node("create cube shadowmap", RenderGraphQueue::DefaultGraphics);
+                let cube_map_node = context.graph.add_renderpass_node(
+                    "create cube shadowmap",
+                    RenderGraphQueue::DefaultGraphics,
+                );
 
                 let cube_map_xy_size = 1024;
 
@@ -103,7 +104,7 @@ fn shadow_map_pass(
 ) -> ShadowMapPass {
     let node = context
         .graph
-        .add_node("Shadow", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("Shadow", RenderGraphQueue::DefaultGraphics);
 
     let depth = context.graph.modify_depth_attachment(
         node,

--- a/rafx-plugins/src/pipelines/basic/graph_generator/ui_pass.rs
+++ b/rafx-plugins/src/pipelines/basic/graph_generator/ui_pass.rs
@@ -17,7 +17,7 @@ pub(super) fn ui_pass(
     // This node has a single color attachment
     let node = context
         .graph
-        .add_node("Ui", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("Ui", RenderGraphQueue::DefaultGraphics);
     let color = context.graph.modify_color_attachment(
         node,
         previous_pass_color,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/bloom_blur_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/bloom_blur_pass.rs
@@ -65,7 +65,7 @@ fn bloom_blur_internal_pass(
 ) -> RenderGraphImageUsageId {
     let node = context
         .graph
-        .add_node("BloomBlur", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("BloomBlur", RenderGraphQueue::DefaultGraphics);
     let blur_dst = context.graph.create_color_attachment(
         node,
         0,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/bloom_combine_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/bloom_combine_pass.rs
@@ -32,7 +32,7 @@ pub(super) fn bloom_combine_pass(
         .clone();
     let node = context
         .graph
-        .add_node("BloomCombine", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("BloomCombine", RenderGraphQueue::DefaultGraphics);
 
     let color = context.graph.create_color_attachment(
         node,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/bloom_extract_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/bloom_extract_pass.rs
@@ -22,7 +22,7 @@ pub(super) fn bloom_extract_pass(
 ) -> BloomExtractPass {
     let node = context
         .graph
-        .add_node("BloomExtract", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("BloomExtract", RenderGraphQueue::DefaultGraphics);
 
     let sdr_image = context.graph.create_color_attachment(
         node,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/cas_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/cas_pass.rs
@@ -19,7 +19,7 @@ pub(super) fn cas_pass(
 ) -> CasPass {
     let node = context
         .graph
-        .add_node("Cas", RenderGraphQueue::DefaultGraphics);
+        .add_callback_node("Cas", RenderGraphQueue::DefaultGraphics);
 
     let src_rt = context.graph.read_storage_image(
         node,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/debug_pip_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/debug_pip_pass.rs
@@ -17,7 +17,7 @@ pub(super) fn debug_pip_pass(
     // This node has a single color attachment
     let node = context
         .graph
-        .add_node("DebugPip", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("DebugPip", RenderGraphQueue::DefaultGraphics);
     let color = context.graph.modify_color_attachment(
         node,
         previous_pass_color,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/depth_prepass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/depth_prepass.rs
@@ -14,7 +14,7 @@ pub(super) struct DepthPrepass {
 pub(super) fn depth_prepass(context: &mut ModernPipelineContext) -> DepthPrepass {
     let node = context
         .graph
-        .add_node("DepthPrepass", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("DepthPrepass", RenderGraphQueue::DefaultGraphics);
 
     let depth = context.graph.create_depth_attachment(
         node,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/depth_pyramid.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/depth_pyramid.rs
@@ -92,7 +92,7 @@ pub(super) fn depth_pyramid_pass(
     for dst_mip_level in 1..mip_levels {
         let node = context
             .graph
-            .add_node("DepthPyramid", RenderGraphQueue::DefaultGraphics);
+            .add_callback_node("DepthPyramid", RenderGraphQueue::DefaultGraphics);
 
         let input_width = 1.max(swapchain_extents.width >> (dst_mip_level - 1));
         let input_height = 1.max(swapchain_extents.height >> (dst_mip_level - 1));

--- a/rafx-plugins/src/pipelines/modern/graph_generator/light_binning.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/light_binning.rs
@@ -68,7 +68,7 @@ pub(super) fn lights_bin_pass(context: &mut ModernPipelineContext) -> LightBinPa
     //
     let node = context
         .graph
-        .add_node("LightsBin", RenderGraphQueue::DefaultGraphics);
+        .add_callback_node("LightsBin", RenderGraphQueue::DefaultGraphics);
 
     let clusters_buffer =
         context
@@ -159,7 +159,7 @@ pub(super) fn lights_build_lists_pass(
 
     let node = context
         .graph
-        .add_node("LightsBuildLists", RenderGraphQueue::DefaultGraphics);
+        .add_callback_node("LightsBuildLists", RenderGraphQueue::DefaultGraphics);
 
     let input_buffer = context.graph.read_storage_buffer(
         node,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/luma_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/luma_pass.rs
@@ -24,7 +24,7 @@ pub(super) fn luma_build_histogram_pass(
 ) -> LumaBuildHistogramPass {
     let node = context
         .graph
-        .add_node("LumaBuildHistogram", RenderGraphQueue::DefaultGraphics);
+        .add_callback_node("LumaBuildHistogram", RenderGraphQueue::DefaultGraphics);
 
     let luma_histogram_data = context.graph.create_storage_buffer(
         node,
@@ -123,7 +123,7 @@ pub(super) fn luma_average_histogram_pass(
 ) -> LumaAverageHistogramPass {
     let node = context
         .graph
-        .add_node("LumaAverageHistogram", RenderGraphQueue::DefaultGraphics);
+        .add_callback_node("LumaAverageHistogram", RenderGraphQueue::DefaultGraphics);
 
     let luma_histogram_data = context.graph.read_storage_buffer(
         node,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/mesh_culling.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/mesh_culling.rs
@@ -32,7 +32,7 @@ pub(super) fn mesh_culling_pass(
 
     let node = context
         .graph
-        .add_node("MeshCulling", RenderGraphQueue::DefaultGraphics);
+        .add_callback_node("MeshCulling", RenderGraphQueue::DefaultGraphics);
 
     let depth_pyramid_mips: Vec<_> = depth_pyramid_pass
         .depth_pyramid_mips

--- a/rafx-plugins/src/pipelines/modern/graph_generator/opaque_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/opaque_pass.rs
@@ -28,7 +28,7 @@ pub(super) fn opaque_pass(
 ) -> OpaquePass {
     let node = context
         .graph
-        .add_node("Opaque", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("Opaque", RenderGraphQueue::DefaultGraphics);
 
     let color = context.graph.create_color_attachment(
         node,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/shadow_map_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/shadow_map_pass.rs
@@ -54,7 +54,7 @@ pub(super) fn shadow_map_passes(
 
     let node = context
         .graph
-        .add_node("Shadow", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("Shadow", RenderGraphQueue::DefaultGraphics);
 
     let clear_value = if shadow_atlas_needs_full_clear {
         Some(RafxDepthStencilClearValue {

--- a/rafx-plugins/src/pipelines/modern/graph_generator/ssao_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/ssao_pass.rs
@@ -61,7 +61,7 @@ pub(super) fn ssao_pass(
 ) -> SsaoPass {
     let node = context
         .graph
-        .add_node("SsaoPass", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("SsaoPass", RenderGraphQueue::DefaultGraphics);
 
     let depth_rt = context.graph.sample_image(
         node,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/taa_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/taa_pass.rs
@@ -24,7 +24,7 @@ pub(super) fn taa_pass(
 ) -> TaaPass {
     let node = context
         .graph
-        .add_node("TaaPass", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("TaaPass", RenderGraphQueue::DefaultGraphics);
 
     let velocity_rt = context.graph.sample_image(
         node,

--- a/rafx-plugins/src/pipelines/modern/graph_generator/ui_pass.rs
+++ b/rafx-plugins/src/pipelines/modern/graph_generator/ui_pass.rs
@@ -17,7 +17,7 @@ pub(super) fn ui_pass(
     // This node has a single color attachment
     let node = context
         .graph
-        .add_node("Ui", RenderGraphQueue::DefaultGraphics);
+        .add_renderpass_node("Ui", RenderGraphQueue::DefaultGraphics);
     let color = context.graph.modify_color_attachment(
         node,
         previous_pass_color,

--- a/rafx/examples/asset_triangle/asset_triangle.rs
+++ b/rafx/examples/asset_triangle/asset_triangle.rs
@@ -259,7 +259,8 @@ fn run() -> RafxResult<()> {
             //
             let mut graph_builder = RenderGraphBuilder::default();
 
-            let node = graph_builder.add_node("opaque", RenderGraphQueue::DefaultGraphics);
+            let node =
+                graph_builder.add_renderpass_node("opaque", RenderGraphQueue::DefaultGraphics);
             let color_attachment = graph_builder.create_color_attachment(
                 node,
                 0,

--- a/rafx/examples/framework_triangle/framework_triangle.rs
+++ b/rafx/examples/framework_triangle/framework_triangle.rs
@@ -227,7 +227,8 @@ fn run() -> RafxResult<()> {
             //
             let mut graph_builder = RenderGraphBuilder::default();
 
-            let node = graph_builder.add_node("opaque", RenderGraphQueue::DefaultGraphics);
+            let node =
+                graph_builder.add_renderpass_node("opaque", RenderGraphQueue::DefaultGraphics);
             let color_attachment = graph_builder.create_color_attachment(
                 node,
                 0,
@@ -248,6 +249,7 @@ fn run() -> RafxResult<()> {
             //
             let captured_vertex_layout = vertex_layout.clone();
             let captured_material_pass = material_pass.clone();
+
             graph_builder.set_renderpass_callback(node, move |args| {
                 let vertex_layout = &captured_vertex_layout;
                 let material_pass = &captured_material_pass;

--- a/rafx/examples/renderer_triangle/example_plugin.rs
+++ b/rafx/examples/renderer_triangle/example_plugin.rs
@@ -43,7 +43,7 @@ impl RendererPipelinePlugin for ExampleRendererPipelinePlugin {
         //
         let mut graph_builder = RenderGraphBuilder::default();
 
-        let node = graph_builder.add_node("opaque", RenderGraphQueue::DefaultGraphics);
+        let node = graph_builder.add_renderpass_node("opaque", RenderGraphQueue::DefaultGraphics);
         let color_attachment = graph_builder.create_color_attachment(
             node,
             0,


### PR DESCRIPTION
This change also substantially improves coverage for supported resource state changes at the end of the graph.