### PR TITLE
bugfix: resolve crash with renderer for demo

### DIFF
--- a/rafx-api/src/extra/swapchain_helper.rs
+++ b/rafx-api/src/extra/swapchain_helper.rs
@@ -52,6 +52,8 @@ impl RafxSwapchainHelperSharedState {
         let mut render_finished_semaphores = Vec::with_capacity(image_count);
         let mut in_flight_fences = Vec::with_capacity(image_count);
 
+        log::debug!("number of images: {}", image_count);
+
         for _ in 0..image_count {
             image_available_semaphores.push(device_context.create_semaphore()?);
             render_finished_semaphores.push(device_context.create_semaphore()?);

--- a/rafx-renderer/src/renderer.rs
+++ b/rafx-renderer/src/renderer.rs
@@ -5,6 +5,7 @@ use rafx_framework::render_features::render_features_prelude::*;
 use rafx_framework::visibility::{VisibilityConfig, VisibilityResource};
 use rafx_framework::{ImageViewResource, ResourceArc};
 use rafx_framework::{RenderResources, ResourceLookupSet};
+use rafx_framework::MAX_FRAMES_IN_FLIGHT;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -600,12 +601,12 @@ impl Renderer {
         render_resources
             .fetch_mut::<AssetManagerRenderResource>()
             .end_extract();
-
+        
         //TODO: This is now possible to run on the render thread
         let prepared_render_graph = renderer.pipeline_plugin.generate_render_graph(
             asset_manager,
             swapchain_image,
-            presentable_frame.rotating_frame_index(),
+            presentable_frame.incrementing_frame_index() % MAX_FRAMES_IN_FLIGHT,
             main_view.clone(),
             extract_resources,
             render_resources,


### PR DESCRIPTION
I have a swap chain with 5 buffers in vulkan? could the definition be expanded with a minimum looks like you're querying for the supported number of swap chain and then requesting the max number of images in the swapchain?

using the MAX_FRAMES_IN_FLIGHT against the current frame should be safe. we're just iterating over 5 frame buffers but are bound to two active frames in flight. 

![image](https://github.com/aclysma/rafx/assets/854359/5342c381-60b0-45dc-8a1a-c31cfb0759cb)
